### PR TITLE
Fixes assumption that int == int64.

### DIFF
--- a/length_test.go
+++ b/length_test.go
@@ -11,7 +11,7 @@ func TestReadLength(t *testing.T) {
 	testcases := map[string]struct {
 		Data []byte
 
-		ExpectedLength    int
+		ExpectedLength    int64
 		ExpectedBytesRead int
 		ExpectedError     string
 	}{
@@ -112,7 +112,7 @@ func TestReadLength(t *testing.T) {
 
 func TestEncodeLength(t *testing.T) {
 	testcases := map[string]struct {
-		Length        int
+		Length        int64
 		ExpectedBytes []byte
 	}{
 		"0": {


### PR DESCRIPTION
This breaks on non 64-bit architectures.

https://bugs.debian.org/cgi-bin/bugreport.cgi?archive=no&bug=860633