### PR TITLE
export parseInt64()

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -207,7 +207,7 @@ func DecodeString(data []byte) string {
 	return string(data)
 }
 
-func parseInt64(bytes []byte) (ret int64, err error) {
+func ParseInt64(bytes []byte) (ret int64, err error) {
 	if len(bytes) > 8 {
 		// We'll overflow an int64 in this case.
 		err = fmt.Errorf("integer too large")
@@ -349,11 +349,11 @@ func readPacket(reader io.Reader) (*Packet, int, error) {
 		switch p.Tag {
 		case TagEOC:
 		case TagBoolean:
-			val, _ := parseInt64(content)
+			val, _ := ParseInt64(content)
 
 			p.Value = val != 0
 		case TagInteger:
-			p.Value, _ = parseInt64(content)
+			p.Value, _ = ParseInt64(content)
 		case TagBitString:
 		case TagOctetString:
 			// the actual string encoding is not known here
@@ -366,7 +366,7 @@ func readPacket(reader io.Reader) (*Packet, int, error) {
 		case TagExternal:
 		case TagRealFloat:
 		case TagEnumerated:
-			p.Value, _ = parseInt64(content)
+			p.Value, _ = ParseInt64(content)
 		case TagEmbeddedPDV:
 		case TagUTF8String:
 			p.Value = DecodeString(content)

--- a/ber_test.go
+++ b/ber_test.go
@@ -11,12 +11,12 @@ import (
 func TestEncodeDecodeInteger(t *testing.T) {
 	for _, v := range []int64{0, 10, 128, 1024, math.MaxInt64, -1, -100, -128, -1024, math.MinInt64} {
 		enc := encodeInteger(v)
-		dec, err := parseInt64(enc)
+		dec, err := ParseInt64(enc)
 		if err != nil {
 			t.Fatalf("Error decoding %d : %s", v, err)
 		}
 		if v != dec {
-			t.Error("TestEncodeDecodeInteger failed for %d (got %d)", v, dec)
+			t.Errorf("TestEncodeDecodeInteger failed for %d (got %d)", v, dec)
 		}
 
 	}


### PR DESCRIPTION
and fix warning in test

see e.g. https://github.com/vetinari/ldap/blob/extend-controls/controls/behera.go#L116 on use 