### PR TITLE
add validation of string types

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"unicode/utf8"
 )
 
 // MaxPacketLengthBytes specifies the maximum allowed packet size when calling ReadPacket or DecodePacket. Set to 0 for
@@ -377,16 +378,34 @@ func readPacket(reader io.Reader) (*Packet, int, error) {
 			p.Value, _ = ParseInt64(content)
 		case TagEmbeddedPDV:
 		case TagUTF8String:
-			p.Value = DecodeString(content)
+			val := DecodeString(content)
+			if !utf8.Valid([]byte(val)) {
+				err = errors.New("invalid UTF-8 string")
+			} else {
+				p.Value = val
+			}
 		case TagRelativeOID:
 		case TagSequence:
 		case TagSet:
 		case TagNumericString:
 		case TagPrintableString:
-			p.Value = DecodeString(content)
+			val := DecodeString(content)
+			if err = isPrintableString(val); err == nil {
+				p.Value = val
+			}
 		case TagT61String:
 		case TagVideotexString:
 		case TagIA5String:
+			val := DecodeString(content)
+			for i, c := range val {
+				if c >= 0x7F {
+					err = fmt.Errorf("invalid character for IA5String at pos %d: %c", i, c)
+					break
+				}
+			}
+			if err == nil {
+				p.Value = val
+			}
 		case TagUTCTime:
 		case TagGeneralizedTime:
 		case TagGraphicString:
@@ -400,7 +419,24 @@ func readPacket(reader io.Reader) (*Packet, int, error) {
 		p.Data.Write(content)
 	}
 
-	return p, read, nil
+	return p, read, err
+}
+
+func isPrintableString(val string) error {
+	for i, c := range val {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		default:
+			switch c {
+			case '\'', '(', ')', '+', ',', '-', '.', '=', '/', ':', '?', ' ':
+			default:
+				return fmt.Errorf("invalid character in position %d", i)
+			}
+		}
+	}
+	return nil
 }
 
 func (p *Packet) Bytes() []byte {

--- a/string_test.go
+++ b/string_test.go
@@ -1,0 +1,80 @@
+package ber
+
+import (
+	"testing"
+)
+
+func TestIA5String(t *testing.T) {
+	for _, test := range []struct {
+		value       string
+		expectedErr string
+	}{
+		{"asdfgh", ""},
+		{"asdfgå", "invalid character for IA5String at pos 5: å"},
+	} {
+		pkt := NewString(ClassUniversal, TypePrimitive, TagIA5String, test.value, test.value)
+		dec, err := DecodePacketErr(pkt.Bytes())
+		if err == nil {
+			if test.expectedErr != "" {
+				t.Errorf("got unexpected error for `%s`: %s", test.value, err)
+			}
+			if dec.Value.(string) != test.value {
+				t.Errorf("did not get back original value: %s <=> %s", dec.Value.(string), test.value)
+			}
+		} else {
+			if err.Error() != test.expectedErr {
+				t.Errorf("got unexpected error for `%s`: %s", test.value, err)
+			}
+		}
+	}
+}
+
+func TestPrintableString(t *testing.T) {
+	for _, test := range []struct {
+		value       string
+		expectedErr string
+	}{
+		{"asdfgh", ""},
+		{"asdfgå", "invalid character in position 5"},
+	} {
+		pkt := NewString(ClassUniversal, TypePrimitive, TagPrintableString, test.value, test.value)
+		dec, err := DecodePacketErr(pkt.Bytes())
+		if err == nil {
+			if test.expectedErr != "" {
+				t.Errorf("got unexpected error for `%s`: %s", test.value, err)
+			}
+			if dec.Value.(string) != test.value {
+				t.Errorf("did not get back original value: %s <=> %s", dec.Value.(string), test.value)
+			}
+		} else {
+			if err.Error() != test.expectedErr {
+				t.Errorf("got unexpected error for `%s`: %s", test.value, err)
+			}
+		}
+	}
+}
+
+func TestUTF8String(t *testing.T) {
+	for _, test := range []struct {
+		value       string
+		expectedErr string
+	}{
+		{"åäöüß", ""},
+		{"asdfg\xFF", "invalid UTF-8 string"},
+	} {
+		pkt := NewString(ClassUniversal, TypePrimitive, TagUTF8String, test.value, test.value)
+		dec, err := DecodePacketErr(pkt.Bytes())
+		if err == nil {
+			if test.expectedErr != "" {
+				t.Errorf("got unexpected error for `%s`: %s", test.value, err)
+			}
+			if dec.Value.(string) != test.value {
+				t.Errorf("did not get back original value: %s <=> %s", dec.Value.(string), test.value)
+			}
+		} else {
+			if err.Error() != test.expectedErr {
+				t.Errorf("got unexpected error for `%s`: %s", test.value, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
for UTF8String, PrintableString and IA5String

note: this may break things when the received payload is not valid for the given tags