### PR TITLE
Add RFC4511-compliant boolean type

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -472,6 +472,22 @@ func NewBoolean(ClassType Class, TagType Type, Tag Tag, Value bool, Description 
 	return p
 }
 
+// NewLDAPBoolean returns a RFC 4511-compliant Boolean packet
+func NewLDAPBoolean(Value bool, Description string) *Packet {
+	intValue := int64(0)
+
+	if Value {
+		intValue = 255
+	}
+
+	p := Encode(ClassUniversal, TypePrimitive, TagBoolean, nil, Description)
+
+	p.Value = Value
+	p.Data.Write(encodeInteger(intValue))
+
+	return p
+}
+
 func NewInteger(ClassType Class, TagType Type, Tag Tag, Value interface{}, Description string) *Packet {
 	p := Encode(ClassType, TagType, Tag, nil, Description)
 

--- a/ber_test.go
+++ b/ber_test.go
@@ -42,6 +42,27 @@ func TestBoolean(t *testing.T) {
 
 }
 
+func TestLDAPBoolean(t *testing.T) {
+	var value bool = true
+
+	packet := NewLDAPBoolean(value, "first Packet, True")
+
+	newBoolean, ok := packet.Value.(bool)
+	if !ok || newBoolean != value {
+		t.Error("error during creating packet")
+	}
+
+	encodedPacket := packet.Bytes()
+
+	newPacket := DecodePacket(encodedPacket)
+
+	newBoolean, ok = newPacket.Value.(bool)
+	if !ok || newBoolean != value {
+		t.Error("error during decoding packet")
+	}
+
+}
+
 func TestInteger(t *testing.T) {
 	var value int64 = 10
 


### PR DESCRIPTION
From RFC 4511:
> If the value of a BOOLEAN type is true, the encoding of the value octet is set to hex “FF”

While the BER encoding is less restrictive, I think it useful to include the RFC4511-compliant type here for use in any downstream LDAP libraries.

See: https://github.com/go-ldap/ldap/issues/194