### PR TITLE
Accomodate extensible filter usage with NewLDAPBoolean

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -473,14 +473,14 @@ func NewBoolean(ClassType Class, TagType Type, Tag Tag, Value bool, Description 
 }
 
 // NewLDAPBoolean returns a RFC 4511-compliant Boolean packet
-func NewLDAPBoolean(Value bool, Description string) *Packet {
+func NewLDAPBoolean(ClassType Class, TagType Type, Tag Tag, Value bool, Description string) *Packet {
 	intValue := int64(0)
 
 	if Value {
 		intValue = 255
 	}
 
-	p := Encode(ClassUniversal, TypePrimitive, TagBoolean, nil, Description)
+	p := Encode(ClassType, TagType, Tag, nil, Description)
 
 	p.Value = Value
 	p.Data.Write(encodeInteger(intValue))

--- a/ber_test.go
+++ b/ber_test.go
@@ -45,7 +45,7 @@ func TestBoolean(t *testing.T) {
 func TestLDAPBoolean(t *testing.T) {
 	var value bool = true
 
-	packet := NewLDAPBoolean(value, "first Packet, True")
+	packet := NewLDAPBoolean(ClassUniversal, TypePrimitive, TagBoolean, value, "first Packet, True")
 
 	newBoolean, ok := packet.Value.(bool)
 	if !ok || newBoolean != value {


### PR DESCRIPTION
Made my original change in https://github.com/go-asn1-ber/asn1-ber/pull/25 less flexible than I should have. There is at least one boolean usage in the downstream go-ldap library that does not use the universal class nor the boolean tag: [[source]](https://github.com/go-ldap/ldap/blob/v3.1.7/filter.go#L394).

go test:
```console
=== RUN   TestEncodeDecodeInteger
--- PASS: TestEncodeDecodeInteger (0.00s)
=== RUN   TestBoolean
--- PASS: TestBoolean (0.00s)
=== RUN   TestLDAPBoolean
--- PASS: TestLDAPBoolean (0.00s)
=== RUN   TestInteger
--- PASS: TestInteger (0.00s)
=== RUN   TestString
--- PASS: TestString (0.00s)
=== RUN   TestSequenceAndAppendChild
--- PASS: TestSequenceAndAppendChild (0.00s)
=== RUN   TestReadPacket
--- PASS: TestReadPacket (0.00s)
=== RUN   TestBinaryInteger
--- PASS: TestBinaryInteger (0.00s)
=== RUN   TestBinaryOctetString
--- PASS: TestBinaryOctetString (0.00s)
=== RUN   TestReadHeader
--- PASS: TestReadHeader (0.00s)
=== RUN   TestReadIdentifier
--- PASS: TestReadIdentifier (0.00s)
=== RUN   TestEncodeIdentifier
--- PASS: TestEncodeIdentifier (0.00s)
=== RUN   TestEncodeHighTag
--- PASS: TestEncodeHighTag (0.00s)
=== RUN   TestReadLength
--- PASS: TestReadLength (0.00s)
=== RUN   TestEncodeLength
--- PASS: TestEncodeLength (0.00s)
=== RUN   TestSuiteDecodePacket
--- PASS: TestSuiteDecodePacket (0.00s)
=== RUN   TestSuiteReadPacket
--- PASS: TestSuiteReadPacket (0.00s)
PASS
ok  	github.com/go-asn1-ber/asn1-ber	0.004s
```