### PR TITLE
added more tagtypes for byte slice encoding to ber.Encode

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -446,10 +446,32 @@ func Encode(ClassType Class, TagType Type, Tag Tag, Value interface{}, Descripti
 				if ok {
 					p.Data.Write([]byte(sv))
 				}
+			case TagEnumerated:
+				bv, ok := v.Interface().([]byte)
+				if ok {
+					p.Data.Write(bv)
+				}
+			case TagEmbeddedPDV:
+				bv, ok := v.Interface().([]byte)
+				if ok {
+					p.Data.Write(bv)
+				}
+			}
+		} else if ClassType == ClassContext {
+			switch Tag {
+			case TagEnumerated:
+				bv, ok := v.Interface().([]byte)
+				if ok {
+					p.Data.Write(bv)
+				}
+			case TagEmbeddedPDV:
+				bv, ok := v.Interface().([]byte)
+				if ok {
+					p.Data.Write(bv)
+				}
 			}
 		}
 	}
-
 	return p
 }
 


### PR DESCRIPTION
I did some work recently adding NTLMSSP support to github.com/go-ldap/ldap/v3, and needed to add a few more supported tag and class types to ber.Encode to get it working

From what I could tell, it currently only supports ClassUniversal and TagOctetString, so I added the ability to encode arbitrary byte slices with ClassContext and TagEnumerated/TagEmbeddedPV

I won't pretend to fully understand ASN1 BER, so I'm not sure if this is fully compliant, but it works for me and was necessary to get NTLMSSP working with go-ldap (separate PR incoming there). 

Let me know what you think if this this is acceptable!