### PR TITLE
29 generalized time bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,30 @@
 language: go
-matrix:
-  include:
-    - go: 1.2.x
-      env: GOOS=linux GOARCH=amd64
-    - go: 1.2.x
-      env: GOOS=linux GOARCH=386
-    - go: 1.2.x
-      env: GOOS=windows GOARCH=amd64
-    - go: 1.2.x
-      env: GOOS=windows GOARCH=386
-    - go: 1.3.x
-    - go: 1.4.x
-    - go: 1.5.x
-    - go: 1.6.x
-    - go: 1.7.x
-    - go: 1.8.x
-    - go: 1.9.x
-    - go: 1.10.x
-    - go: 1.11.x
-    - go: 1.12.x
-    - go: 1.13.x
-    - go: 1.14.x
-      env: GOOS=linux GOARCH=amd64
-    - go: 1.14.x
-      env: GOOS=linux GOARCH=386
-    - go: 1.14.x
-      env: GOOS=windows GOARCH=amd64
-    - go: 1.14.x
-      env: GOOS=windows GOARCH=386
-    - go: tip
-go_import_path: gopkg.in/asn-ber.v1
-install:
-  - go list -f '{{range .Imports}}{{.}} {{end}}' ./... | xargs go get -v
-  - go list -f '{{range .TestImports}}{{.}} {{end}}' ./... | xargs go get -v
-  - go get code.google.com/p/go.tools/cmd/cover || go get golang.org/x/tools/cmd/cover
-  - go build -v ./...
+
+go:
+  - 1.2.x
+  - 1.6.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - 1.14.x
+  - tip
+
+os:
+  - linux
+  - osx
+  - windows
+
+arch:
+  - amd64
+  - arm64
+
+dist: bionic
+
+env:
+  jobs:
+    - GOARCH=386
+    - GOARCH=amd64
+
 script:
   - go test -v -cover ./... || go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,28 @@ go:
 
 os:
   - linux
-  - osx
-  - windows
 
 arch:
   - amd64
-  - arm64
 
-dist: bionic
+dist: xenial
 
 env:
-  jobs:
-    - GOARCH=386
-    - GOARCH=amd64
+  - GOARCH=amd64
+
+jobs:
+  include:
+    - os: windows
+      go: 1.14.x
+    - os: osx
+      go: 1.14.x
+    - os: linux
+      go: 1.14.x
+      arch: arm64
+    - os: linux
+      go: 1.14.x
+      env:
+        - GOARCH=386
 
 script:
   - go test -v -cover ./... || go test -v ./...

--- a/generalizedTime.go
+++ b/generalizedTime.go
@@ -59,10 +59,10 @@ func ParseGeneralizedTime(v []byte) (time.Time, error) {
 		tzIndex = dot
 
 		if dot == 10 {
-			fract = time.Duration(int(f * float64(time.Hour)))
+			fract = time.Duration(int64(f * float64(time.Hour)))
 			format = `2006010215Z`
 		} else {
-			fract = time.Duration(int(f * float64(time.Minute)))
+			fract = time.Duration(int64(f * float64(time.Minute)))
 			format = `200601021504Z`
 		}
 

--- a/generalizedTime.go
+++ b/generalizedTime.go
@@ -13,6 +13,10 @@ var ErrInvalidTimeFormat = errors.New("invalid time format")
 
 var zeroTime = time.Time{}
 
+// ParseGeneralizedTime parses a string value and if it conforms to
+// GeneralizedTime[^0] format, will return a time.Time for that value.
+//
+// [^0]: https://www.itu.int/rec/T-REC-X.690-201508-I/en Section 11.7
 func ParseGeneralizedTime(v []byte) (time.Time, error) {
 	var format string
 	var fract time.Duration


### PR DESCRIPTION
- Fix #29 :: ParseGeneralizedTime should explicitly use int64
- Add missing comment doc
- Travis Updates
