### PR TITLE
Buffered reads

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -1,6 +1,7 @@
 package ber
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -284,6 +285,7 @@ func DecodePacketErr(data []byte) (*Packet, error) {
 
 // readPacket reads a single Packet from the reader, returning the number of bytes read.
 func readPacket(reader io.Reader) (*Packet, int, error) {
+	reader = bufio.NewReader(reader)
 	identifier, length, read, err := readHeader(reader)
 	if err != nil {
 		return nil, read, err

--- a/suite_test.go
+++ b/suite_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 )
 
@@ -193,4 +194,50 @@ func TestSuiteReadPacket(t *testing.T) {
 			t.Errorf("%s: data should be the same\nwant: %#v\ngot: %#v", file, dataOut, dataOut2)
 		}
 	}
+}
+
+func largeBER(t testing.TB, n int) *Packet {
+	packet := Encode(ClassUniversal, TypeConstructed, TagSequence, nil, "LDAP Request")
+	packet.AppendChild(NewInteger(ClassUniversal, TypePrimitive, TagInteger, 20, "MessageID"))
+	for i := 0; i < n; i++ {
+		srp := Encode(ClassApplication, TypeConstructed, 3, nil, "Search Request")
+		srp.AppendChild(NewString(ClassUniversal, TypePrimitive, TagOctetString, "dc=example,dc=com", "Base DN"))
+		srp.AppendChild(NewInteger(ClassUniversal, TypePrimitive, TagEnumerated, uint64(2), "Scope"))
+		srp.AppendChild(NewInteger(ClassUniversal, TypePrimitive, TagEnumerated, uint64(3), "Deref Aliases"))
+		srp.AppendChild(NewInteger(ClassUniversal, TypePrimitive, TagInteger, uint64(0), "Size Limit"))
+		srp.AppendChild(NewInteger(ClassUniversal, TypePrimitive, TagInteger, uint64(0), "Time Limit"))
+		srp.AppendChild(NewBoolean(ClassUniversal, TypePrimitive, TagBoolean, false, "Types Only"))
+		packet.AppendChild(srp)
+	}
+	return packet
+}
+
+func BenchmarkReadPacket(b *testing.B) {
+	benchFile := "tests/bench.ber"
+	p := largeBER(b, 20000)
+	err := ioutil.WriteFile("tests/bench.ber", p.Bytes(), 0777)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(benchFile)
+
+	f, err := os.Open("tests/bench.ber")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		_, err := f.Seek(0, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		_, err = ReadPacket(f)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
 }


### PR DESCRIPTION
Introducing a buffered reader seems to improve the performance of decoding packets substantially. 

The benchmark that this PR introduces is somewhat flawed in that it measures reads from disk instead of from the network, but the reasoning was that reading byte-by-byte through syscalls is most easily replicated this way. 

```
$ benchstat old.txt new.txt
name          old time/op  new time/op  delta
ReadPacket-8   324ms ± 1%    59ms ± 1%  -81.71%  (p=0.002 n=6+6)
```
Benchmark on my machine before:

```
goos: linux
goarch: amd64
pkg: github.com/go-asn1-ber/asn1-ber
BenchmarkReadPacket
BenchmarkReadPacket-8   	       4	 321296674 ns/op
PASS
ok  	github.com/go-asn1-ber/asn1-ber	3.468s
```

and after:
```
goos: linux
goarch: amd64
pkg: github.com/go-asn1-ber/asn1-ber
BenchmarkReadPacket
BenchmarkReadPacket-8   	      19	  59258121 ns/op
PASS
ok  	github.com/go-asn1-ber/asn1-ber	2.349s
```