### PR TITLE
Export function to doisplay packet content

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -170,12 +170,10 @@ func PrintPacket(p *Packet) {
 	printPacket(os.Stdout, p, 0, false)
 }
 
-func printPacket(out io.Writer, p *Packet, indent int, printBytes bool) {
-	indentStr := ""
-
-	for len(indentStr) != indent {
-		indentStr += " "
-	}
+// Return a string describing packet content. This is not recursive,
+// If the packet is a sequence, use `printPacket()`, or browse
+// sequence yourself.
+func DescribePacket(p *Packet) string {
 
 	classStr := ClassMap[p.ClassType]
 
@@ -194,7 +192,17 @@ func printPacket(out io.Writer, p *Packet, indent int, printBytes bool) {
 		description = p.Description + ": "
 	}
 
-	_, _ = fmt.Fprintf(out, "%s%s(%s, %s, %s) Len=%d %q\n", indentStr, description, classStr, tagTypeStr, tagStr, p.Data.Len(), value)
+	return fmt.Sprintf("%s(%s, %s, %s) Len=%d %q", description, classStr, tagTypeStr, tagStr, p.Data.Len(), value)
+}
+
+func printPacket(out io.Writer, p *Packet, indent int, printBytes bool) {
+	indentStr := ""
+
+	for len(indentStr) != indent {
+		indentStr += " "
+	}
+
+	_, _ = fmt.Fprintf(out, "%s%s\n", indentStr, DescribePacket(p))
 
 	if printBytes {
 		PrintBytes(out, p.Bytes(), indentStr)


### PR DESCRIPTION
This patch split PrintPacket in two parts, the second part is DescribePacket a function which describe the packet content without recursion, indentation, nor jump line.

The goal is providing a simple way logging detailled protocol errors on speciafic output (other than io.Stdout)

Obviously this patch doesn't break the API or the behaviour of the project.