### PR TITLE
Address panics in parseBinaryFloat, add fuzzer

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,50 @@
+//go:build go1.18
+// +build go1.18
+
+// Fuzzing test(s) are gated behind build tags in order to avoid generating errors
+// when running on versions of Go that do not support fuzzing. This was added in
+// Go 1.18.
+
+package ber
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func FuzzDecodePacket(f *testing.F) {
+	// Seed the fuzz corpus with the test cases defined in suite_test.go
+	for _, tc := range testCases {
+		file := tc.File
+
+		dataIn, err := os.ReadFile(file)
+		if err != nil {
+			f.Fatalf("failed to load file %s into fuzz corpus: %v", file, err)
+			continue
+		}
+		f.Add(dataIn)
+	}
+
+	// Seed the fuzz corpus with data known to cause panics in the past
+	f.Add([]byte{0x09, 0x02, 0x85, 0x30})
+	f.Add([]byte{0x09, 0x01, 0xcf})
+
+	// Set a limit on the length decoded in readPacket() since the call to
+	// make([]byte, length) can allocate up to MaxPacketLengthBytes which is
+	// currently 2 GB. This can cause memory related crashes when fuzzing in
+	// parallel or on memory constrained devices.
+	MaxPacketLengthBytes = 65536
+	f.Fuzz(func(t *testing.T, data []byte) {
+		stime := time.Now()
+		p, err := DecodePacketErr(data)
+
+		if e := time.Since(stime); e > (time.Millisecond * 500) {
+			t.Fatalf("DecodePacketErr took too long: %s", e)
+		}
+
+		if p == nil && err == nil {
+			t.Fatalf("DecodePacketErr returned a nil packet and no error")
+		}
+	})
+}

--- a/real.go
+++ b/real.go
@@ -89,11 +89,17 @@ func parseBinaryFloat(v []byte) (float64, error) {
 	case 0x02:
 		expLen = 3
 	case 0x03:
+		if len(v) < 2 {
+			return 0.0, errors.New("invalid data")
+		}
 		expLen = int(v[0])
 		if expLen > 8 {
 			return 0.0, errors.New("too big value of exponent")
 		}
 		v = v[1:]
+	}
+	if expLen > len(v) {
+		return 0.0, errors.New("too big value of exponent")
 	}
 	buf, v = v[:expLen], v[expLen:]
 	exponent, err := ParseInt64(buf)

--- a/suite_test.go
+++ b/suite_test.go
@@ -170,10 +170,14 @@ func FuzzDecodePacket(f *testing.F) {
 	MaxPacketLengthBytes = 65536
 	f.Fuzz(func(t *testing.T, data []byte) {
 		stime := time.Now()
-		_, _ = DecodePacketErr(data)
+		p, err := DecodePacketErr(data)
 
 		if e := time.Since(stime); e > (time.Millisecond * 500) {
-			t.Fatalf("DecodePacket took too long: %s", e)
+			t.Fatalf("DecodePacketErr took too long: %s", e)
+		}
+
+		if p == nil && err == nil {
+			t.Fatalf("DecodePacketErr returned a nil packet and no error")
 		}
 	})
 }

--- a/suite_test.go
+++ b/suite_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math"
 	"testing"
+	"time"
 )
 
 var errEOF = io.ErrUnexpectedEOF.Error()
@@ -143,6 +144,38 @@ func TestSuiteDecodePacket(t *testing.T) {
 			t.Errorf("%s: data should be the same\nwant: %#v\ngot: %#v", file, dataOut, dataOut2)
 		}
 	}
+}
+
+func FuzzDecodePacket(f *testing.F) {
+	// Seed the fuzz corpus with the test cases
+	for _, tc := range testCases {
+		file := tc.File
+
+		dataIn, err := ioutil.ReadFile(file)
+		if err != nil {
+			f.Fatalf("failed to load file %s into fuzz corpus: %v", file, err)
+			continue
+		}
+		f.Add(dataIn)
+	}
+
+	// Seed the fuzz corpus with data known to cause panics in the past
+	f.Add([]byte{0x09, 0x02, 0x85, 0x30})
+	f.Add([]byte{0x09, 0x01, 0xcf})
+
+	// Set a limit on the length decoded in readPacket() since the call to
+	// make([]byte, length) can allocate up to MaxPacketLengthBytes which is
+	// currently 2 GB. This can cause memory related crashes when fuzzing in
+	// parallel or on memory constrained devices.
+	MaxPacketLengthBytes = 65536
+	f.Fuzz(func(t *testing.T, data []byte) {
+		stime := time.Now()
+		_, _ = DecodePacketErr(data)
+
+		if e := time.Since(stime); e > (time.Millisecond * 500) {
+			t.Fatalf("DecodePacket took too long: %s", e)
+		}
+	})
 }
 
 func TestSuiteReadPacket(t *testing.T) {


### PR DESCRIPTION
This PR addresses two indexing related panics in `parseBinaryFloat`.  It also adds a fuzzer for `DecodePacketErr` to help identify similar issues in the future.

The fuzzer can be run using the following command:
`go test -v -fuzz ^FuzzDecodePacket$ .`

The following reproducer will trigger the panics. Uncomment the second `data=` block to trigger that one.

```go
package main

import (
	ber "github.com/go-asn1-ber/asn1-ber"
)

func main() {
	// panic: runtime error: slice bounds out of range [:2] with capacity 1
	// parseBinaryFloat - asn1-ber@v1.5.4/real.go:98
	// https://github.com/go-asn1-ber/asn1-ber/blob/master/real.go#L98-L99
	// Root cause: failure to check length of 'v' before before indexing into it
	data := []byte{0x09, 0x02, 0x85, 0x30}

	// panic: runtime error: index out of range [0] with length 0
	// parseBinaryFloat - asn1-ber@v1.5.4/real.go:92
	// https://github.com/go-asn1-ber/asn1-ber/blob/3c992f0d6bf4482d85368da48d2a37fa6a5a120b/real.go#L92
	// Root cause: failure to check length of slice 'v' before indexing into it
	//data = []byte{0x09, 0x01, 0xcf}

	_ = ber.DecodePacket(data)
}
```