### PR TITLE
Correct Implementation for Relative OIDs

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -412,7 +412,7 @@ func readPacket(reader io.Reader) (*Packet, int, error) {
 				p.Value = val
 			}
 		case TagRelativeOID:
-			oid, err := parseObjectIdentifier(content)
+			oid, err := parseRelativeObjectIdentifier(content)
 			if err == nil {
 				p.Value = OIDToString(oid)
 			}
@@ -663,6 +663,25 @@ func NewOID(classType Class, tagType Type, tag Tag, value interface{}, descripti
 	return p
 }
 
+func NewRelativeOID(classType Class, tagType Type, tag Tag, value interface{}, description string) *Packet {
+	p := Encode(classType, tagType, tag, nil, description)
+
+	switch v := value.(type) {
+	case string:
+		encoded, err := encodeRelativeOID(v)
+		if err != nil {
+			fmt.Printf("failed writing %v", err)
+			return nil
+		}
+		p.Value = v
+		p.Data.Write(encoded)
+		// TODO: support []int already ?
+	default:
+		panic(fmt.Sprintf("Invalid type %T, expected float{64|32}", v))
+	}
+	return p
+}
+
 // encodeOID takes a string representation of an OID and returns its DER-encoded byte slice along with any error.
 func encodeOID(oidString string) ([]byte, error) {
 	// Convert the string representation to an asn1.ObjectIdentifier
@@ -682,6 +701,27 @@ func encodeOID(oidString string) ([]byte, error) {
 
 	encoded = appendBase128Int(encoded[:0], int64(oid[0]*40+oid[1]))
 	for i := 2; i < len(oid); i++ {
+		encoded = appendBase128Int(encoded, int64(oid[i]))
+	}
+
+	return encoded, nil
+}
+
+func encodeRelativeOID(oidString string) ([]byte, error) {
+	// Convert the string representation to an asn1.ObjectIdentifier
+	parts := strings.Split(oidString, ".")
+	oid := make([]int, len(parts))
+	for i, part := range parts {
+		var val int
+		if _, err := fmt.Sscanf(part, "%d", &val); err != nil {
+			return nil, fmt.Errorf("invalid OID part '%s': %w", part, err)
+		}
+		oid[i] = val
+	}
+
+	encoded := make([]byte, 0)
+
+	for i := 0; i < len(oid); i++ {
 		encoded = appendBase128Int(encoded, int64(oid[i]))
 	}
 
@@ -761,6 +801,37 @@ func parseObjectIdentifier(bytes []byte) (s []int, err error) {
 	}
 
 	i := 2
+	for ; offset < len(bytes); i++ {
+		v, offset, err = parseBase128Int(bytes, offset)
+		if err != nil {
+			return
+		}
+		s[i] = v
+	}
+	s = s[0:i]
+	return
+}
+
+// parseObjectIdentifier parses an OBJECT IDENTIFIER from the given bytes and
+// returns it. An object identifier is a sequence of variable length integers
+// that are assigned in a hierarchy.
+func parseRelativeObjectIdentifier(bytes []byte) (s []int, err error) {
+	if len(bytes) == 0 {
+		err = fmt.Errorf("zero length OBJECT IDENTIFIER")
+		return
+	}
+
+	// In the worst case, we get two elements from the first byte (which is
+	// encoded differently) and then every varint is a single byte long.
+	s = make([]int, len(bytes)+1)
+
+	// The first varint is 40*value1 + value2:
+	// According to this packing, value1 can take the values 0, 1 and 2 only.
+	// When value1 = 0 or value1 = 1, then value2 is <= 39. When value1 = 2,
+	// then there are no restrictions on value2.
+
+	var v, offset int
+	i := 0
 	for ; offset < len(bytes); i++ {
 		v, offset, err = parseBase128Int(bytes, offset)
 		if err != nil {

--- a/ber.go
+++ b/ber.go
@@ -708,13 +708,12 @@ func encodeOID(oidString string) ([]byte, error) {
 }
 
 func encodeRelativeOID(oidString string) ([]byte, error) {
-	// Convert the string representation to an asn1.ObjectIdentifier
 	parts := strings.Split(oidString, ".")
 	oid := make([]int, len(parts))
 	for i, part := range parts {
 		var val int
 		if _, err := fmt.Sscanf(part, "%d", &val); err != nil {
-			return nil, fmt.Errorf("invalid OID part '%s': %w", part, err)
+			return nil, fmt.Errorf("invalid RELATIVE OID part '%s': %w", part, err)
 		}
 		oid[i] = val
 	}
@@ -812,23 +811,13 @@ func parseObjectIdentifier(bytes []byte) (s []int, err error) {
 	return
 }
 
-// parseObjectIdentifier parses an OBJECT IDENTIFIER from the given bytes and
-// returns it. An object identifier is a sequence of variable length integers
-// that are assigned in a hierarchy.
 func parseRelativeObjectIdentifier(bytes []byte) (s []int, err error) {
 	if len(bytes) == 0 {
-		err = fmt.Errorf("zero length OBJECT IDENTIFIER")
+		err = fmt.Errorf("zero length RELATIVE OBJECT IDENTIFIER")
 		return
 	}
 
-	// In the worst case, we get two elements from the first byte (which is
-	// encoded differently) and then every varint is a single byte long.
 	s = make([]int, len(bytes)+1)
-
-	// The first varint is 40*value1 + value2:
-	// According to this packing, value1 can take the values 0, 1 and 2 only.
-	// When value1 = 0 or value1 = 1, then value2 is <= 39. When value1 = 2,
-	// then there are no restrictions on value2.
 
 	var v, offset int
 	i := 0

--- a/ber_test.go
+++ b/ber_test.go
@@ -101,7 +101,7 @@ func TestString(t *testing.T) {
 }
 
 func TestEncodeDecodeOID(t *testing.T) {
-	for _, v := range []string{"0.1", "1.1", "2.3", "0.4", "0.4.5.1888", "0.10.5.1888.234.324234"} {
+	for _, v := range []string{"0.1", "2.981", "2.3", "0.4", "0.4.5.1888", "0.10.5.1888.234.324234"} {
 		enc, err := encodeOID(v)
 		if err != nil {
 			t.Errorf("error on encoding object identifier when encoding %s: %v", v, err)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/go-asn1-ber/asn1-ber
+module gopkg.in/asn1-ber.v1
 
-go 1.13
+go 1.21

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module gopkg.in/asn1-ber.v1
+module github.com/go-asn1-ber/asn1-ber
 
-go 1.21
+go 1.13


### PR DESCRIPTION
In my misunderstanding of this funkey standard I think I have judged to quickly that OID and RelativeOID can be treated the same. This PR tries to fix this. The mein diofference is the removal of the compression of the first two oid segments into 1 byte.