### PR TITLE
set ldap boolean length to 1 byte

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -560,16 +560,14 @@ func NewBoolean(classType Class, tagType Type, tag Tag, value bool, description 
 
 // NewLDAPBoolean returns a RFC 4511-compliant Boolean packet.
 func NewLDAPBoolean(classType Class, tagType Type, tag Tag, value bool, description string) *Packet {
-	intValue := int64(0)
-
-	if value {
-		intValue = 255
-	}
-
 	p := Encode(classType, tagType, tag, nil, description)
 
 	p.Value = value
-	p.Data.Write(encodeInteger(intValue))
+	if value {
+		p.Data.Write([]byte{255})
+	} else {
+		p.Data.Write([]byte{0})
+	}
 
 	return p
 }


### PR DESCRIPTION
With the current implementation, the length of the boolean(true) is 2 bytes. According to the ber specification, the length of the boolean should be 1 byte. 
https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf 
https://docs.oracle.com/cd/E19476-01/821-0510/def-basic-encoding-rules.html