### PR TITLE
fix: guard against stack overflow on deeply-nested BER packets (#49)

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -19,6 +19,10 @@ import (
 // no limit.
 var MaxPacketLengthBytes int64 = math.MaxInt32
 
+// MaxNestingDepth specifies the maximum allowed nesting depth when calling ReadPacket, DecodePacket, or
+// DecodePacketErr. Set to 0 for no limit.
+var MaxNestingDepth int = 1000
+
 type Packet struct {
 	Identifier
 	Value       interface{}
@@ -218,7 +222,7 @@ func printPacket(out io.Writer, p *Packet, indent int, printBytes bool) {
 
 // ReadPacket reads a single Packet from the reader.
 func ReadPacket(reader io.Reader) (*Packet, error) {
-	p, _, err := readPacket(reader)
+	p, _, err := readPacket(reader, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +282,7 @@ func int64Length(i int64) (numBytes int) {
 // DecodePacket decodes the given bytes into a single Packet
 // If a decode error is encountered, nil is returned.
 func DecodePacket(data []byte) *Packet {
-	p, _, _ := readPacket(bytes.NewBuffer(data))
+	p, _, _ := readPacket(bytes.NewBuffer(data), 0)
 
 	return p
 }
@@ -286,7 +290,7 @@ func DecodePacket(data []byte) *Packet {
 // DecodePacketErr decodes the given bytes into a single Packet
 // If a decode error is encountered, nil is returned.
 func DecodePacketErr(data []byte) (*Packet, error) {
-	p, _, err := readPacket(bytes.NewBuffer(data))
+	p, _, err := readPacket(bytes.NewBuffer(data), 0)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +298,11 @@ func DecodePacketErr(data []byte) (*Packet, error) {
 }
 
 // readPacket reads a single Packet from the reader, returning the number of bytes read.
-func readPacket(reader io.Reader) (*Packet, int, error) {
+func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
+	if MaxNestingDepth > 0 && depth >= MaxNestingDepth {
+		return nil, 0, fmt.Errorf("nesting depth %d exceeds maximum %d", depth, MaxNestingDepth)
+	}
+
 	identifier, length, read, err := readHeader(reader)
 	if err != nil {
 		return nil, read, err
@@ -326,7 +334,7 @@ func readPacket(reader io.Reader) (*Packet, int, error) {
 			}
 
 			// Read the next packet
-			child, r, err := readPacket(reader)
+			child, r, err := readPacket(reader, depth+1)
 			if err != nil {
 				return nil, read, unexpectedEOF(err)
 			}

--- a/ber_test.go
+++ b/ber_test.go
@@ -303,3 +303,37 @@ func TestMaxNestingDepthUnlimited(t *testing.T) {
 		t.Errorf("50 levels with MaxNestingDepth=0: unexpected error %v", err)
 	}
 }
+
+func TestMaxNestingDepthReadPacket(t *testing.T) {
+	old := MaxNestingDepth
+	defer func() { MaxNestingDepth = old }()
+
+	MaxNestingDepth = 5
+
+	// depth=5: should succeed
+	data5 := buildNestedSequence(5)
+	_, err := ReadPacket(bytes.NewReader(data5))
+	if err != nil {
+		t.Errorf("5 levels with MaxNestingDepth=5: expected success, got %v", err)
+	}
+
+	// depth=6: should fail
+	data6 := buildNestedSequence(6)
+	_, err = ReadPacket(bytes.NewReader(data6))
+	if err == nil {
+		t.Error("6 levels with MaxNestingDepth=5: expected error, got nil")
+	}
+}
+
+func TestMaxNestingDepthReadPacketUnlimited(t *testing.T) {
+	old := MaxNestingDepth
+	defer func() { MaxNestingDepth = old }()
+
+	MaxNestingDepth = 0
+
+	data := buildNestedSequence(50)
+	_, err := ReadPacket(bytes.NewReader(data))
+	if err != nil {
+		t.Errorf("50 levels with MaxNestingDepth=0: unexpected error %v", err)
+	}
+}

--- a/ber_test.go
+++ b/ber_test.go
@@ -254,3 +254,52 @@ func TestEOF(t *testing.T) {
 		}
 	}
 }
+
+// buildNestedSequence builds a BER-encoded SEQUENCE nested depth levels deep.
+// Each level wraps the previous; the innermost is an empty SEQUENCE.
+// Only valid for small depth where each length fits in one byte (<= 127 content bytes).
+func buildNestedSequence(depth int) []byte {
+	inner := []byte{0x30, 0x00} // empty SEQUENCE
+	for i := 1; i < depth; i++ {
+		wrapped := make([]byte, 0, 2+len(inner))
+		wrapped = append(wrapped, 0x30, byte(len(inner)))
+		wrapped = append(wrapped, inner...)
+		inner = wrapped
+	}
+	return inner
+}
+
+func TestMaxNestingDepth(t *testing.T) {
+	old := MaxNestingDepth
+	defer func() { MaxNestingDepth = old }()
+
+	MaxNestingDepth = 5
+
+	// depth=5: outermost at depth 0, innermost at depth 4 — should succeed
+	data5 := buildNestedSequence(5)
+	_, err := DecodePacketErr(data5)
+	if err != nil {
+		t.Errorf("5 levels with MaxNestingDepth=5: expected success, got %v", err)
+	}
+
+	// depth=6: requires depth 5 which equals MaxNestingDepth — should fail
+	data6 := buildNestedSequence(6)
+	_, err = DecodePacketErr(data6)
+	if err == nil {
+		t.Error("6 levels with MaxNestingDepth=5: expected error, got nil")
+	}
+}
+
+func TestMaxNestingDepthUnlimited(t *testing.T) {
+	old := MaxNestingDepth
+	defer func() { MaxNestingDepth = old }()
+
+	MaxNestingDepth = 0
+
+	// 50-deep nesting with single-byte lengths — should succeed with no limit
+	data := buildNestedSequence(50)
+	_, err := DecodePacketErr(data)
+	if err != nil {
+		t.Errorf("50 levels with MaxNestingDepth=0: unexpected error %v", err)
+	}
+}


### PR DESCRIPTION
Add MaxNestingDepth (default 1000) checked on each recursive readPacket call, returning an error when the limit is exceeded. Prevents stack overflow via crafted deeply-nested SEQUENCE structures without affecting any legitimate traffic or breaking compatibility.