### PR TITLE
Harden and modernize the BER decoder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,23 +1,23 @@
-name: golangci-lint
+name: Lint
+
 on:
+  push:
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 permissions:
   contents: read
 
 jobs:
   golangci:
-    name: lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.20'
-          cache: false
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+          go-version: stable
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
-          only-new-issues: true
+          version: v2.12.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,39 +1,48 @@
 name: PR
 
 on:
+  push:
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
+
+permissions:
+  contents: read
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [
-          '1.20',
-          '1.19',
-          '1.18',
-          '1.17',
-          '1.16',
-          '1.15',
-          '1.14',
-          '1.13',
-        ]
-    name: Go ${{ matrix.go }}.x PR Validate
+        # stable + oldstable track the two supported upstream Go releases;
+        # "1.22" pins the go.mod floor so we prove the module still builds there.
+        go: [stable, oldstable, "1.22"]
+    name: Go ${{ matrix.go }}
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go build -v ./...
+      - run: go test -v -race -cover -cpu 1,2,4 ./...
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: ${{ matrix.go }}
+  fuzz:
+    runs-on: ubuntu-latest
+    name: Fuzz
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: Fuzz the decoder
+        run: go test -run='^$' -fuzz=FuzzDecodePacket -fuzztime=60s ./...
 
-    - name: Version
-      run: go version
-
-    - name: Build
-      run: go build -v ./...
-
-    - name: Test
-      run: go test -v -cover -race -cpu 1,2,4 ./...
+  vulncheck:
+    runs-on: ubuntu-latest
+    name: govulncheck
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Compiled binaries and test artifacts
+*.exe
+*.test
+*.out
+coverage.txt
+coverage.html
+
+# Go workspace files
+go.work
+go.work.sum
+
+# Editor / OS cruft
+.idea/
+.vscode/
+.DS_Store
+*~

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  # "standard" = errcheck, govet, ineffassign, staticcheck, unused.
+  default: standard
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `NewIntegerErr`, `NewRealErr`, `NewOIDErr`, and `NewRelativeOIDErr`:
+  error-returning variants of the existing constructors that report invalid
+  input instead of panicking or returning `nil`.
+
+### Changed
+
+- Require Go 1.22 or newer.
+- Constructed packets no longer populate the exported `Data` field after
+  decoding or `AppendChild`. Content is now serialized lazily by `Bytes()`;
+  read a constructed packet's content via `Bytes()` or by walking `Children`.
+  This removes an O(depth x subtree) memory amplification.
+- `NewOID` and `NewRelativeOID` now return `nil` instead of panicking on a
+  structurally invalid OID string (matching how they already handled other
+  invalid strings), and are deprecated in favor of the `*Err` variants.
+
+### Deprecated
+
+- `NewOID` and `NewRelativeOID` — use `NewOIDErr` / `NewRelativeOIDErr`.
+
+### Fixed
+
+- OID and Relative-OID parse errors were silently swallowed, so
+  `DecodePacketErr` reported success on a malformed OID; they now propagate.
+- Over-long `INTEGER`/`BOOLEAN`/`ENUMERATED` values (more than 8 bytes)
+  silently decoded to `0`; they are now rejected.
+- `IA5String` incorrectly rejected the valid `0x7F` (DEL) character.
+- An 8-byte long-form length with the high bit set decoded to a negative
+  length and was mistaken for indefinite length; it is now rejected as
+  overflow.
+- `DecodePacket` returned a partially-populated packet on a decode error
+  despite documenting that it returns `nil`.
+- Memory amplification in `AppendChild`, which retained a serialized copy of
+  every subtree at each level.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,69 @@
-[![GoDoc](https://godoc.org/gopkg.in/asn1-ber.v1?status.svg)](https://godoc.org/gopkg.in/asn1-ber.v1) [![Build Status](https://travis-ci.org/go-asn1-ber/asn1-ber.svg)](https://travis-ci.org/go-asn1-ber/asn1-ber)
+# asn1-ber
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/go-asn1-ber/asn1-ber.svg)](https://pkg.go.dev/github.com/go-asn1-ber/asn1-ber)
+[![PR](https://github.com/go-asn1-ber/asn1-ber/actions/workflows/pr.yml/badge.svg)](https://github.com/go-asn1-ber/asn1-ber/actions/workflows/pr.yml)
+[![Lint](https://github.com/go-asn1-ber/asn1-ber/actions/workflows/lint.yml/badge.svg)](https://github.com/go-asn1-ber/asn1-ber/actions/workflows/lint.yml)
 
-ASN1 BER Encoding / Decoding Library for the GO programming language.
----------------------------------------------------------------------
+ASN.1 BER encoding and decoding for Go, with no external dependencies. This is
+the BER layer used by [go-ldap](https://github.com/go-ldap/ldap); it implements
+the subset of BER/DER needed for LDAP (RFC 4511), including integers, booleans,
+strings, object identifiers, REAL numbers, and generalized time.
 
-Required libraries: 
-   None
+## Install
 
-Working:
-   Very basic encoding / decoding needed for LDAP protocol
+```sh
+go get github.com/go-asn1-ber/asn1-ber
+```
 
-Tests Implemented:
-   A few
+Requires Go 1.22 or newer.
 
-TODO:
-   Fix all encoding / decoding to conform to ASN1 BER spec
-   Implement Tests / Benchmarks
+## Usage
 
----
+```go
+package main
 
-The Go gopher was designed by Renee French. (http://reneefrench.blogspot.com/)
-The design is licensed under the Creative Commons 3.0 Attributions license.
-Read this article for more details: http://blog.golang.org/gopher
+import (
+	"fmt"
+
+	ber "github.com/go-asn1-ber/asn1-ber"
+)
+
+func main() {
+	// Encode a SEQUENCE containing a single OCTET STRING.
+	seq := ber.NewSequence("greeting")
+	seq.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "Hello, world", ""))
+
+	// Serialize, then decode back into a packet tree.
+	packet, err := ber.DecodePacketErr(seq.Bytes())
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(packet.Children[0].Value) // Hello, world
+}
+```
+
+`DecodePacketErr` (and `ReadPacket`, which reads from an `io.Reader`) return an
+error on malformed input. `DecodePacket` is an older variant that returns `nil`
+instead; prefer the `Err` form. When decoding untrusted data, the
+`MaxPacketLengthBytes` and `MaxNestingDepth` package variables bound memory and
+recursion.
+
+See the [reference documentation](https://pkg.go.dev/github.com/go-asn1-ber/asn1-ber)
+for the full API.
+
+## Development
+
+```sh
+go test -race ./...                       # unit tests + conformance suite
+go test -run='^$' -fuzz=FuzzDecodePacket  # fuzz the decoder
+golangci-lint run                         # lint
+```
+
+The conformance suite in `tests/` is built from the
+[Strozhevsky ASN.1 test suite](http://www.strozhevsky.com/free_docs/); see
+[tests/README.md](tests/README.md).
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+This library decodes ASN.1 BER, frequently from untrusted network input (for
+example, LDAP messages). Parsing bugs can have security impact, so reports are
+welcome.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately using GitHub's
+[private vulnerability reporting](https://github.com/go-asn1-ber/asn1-ber/security/advisories/new)
+rather than opening a public issue. Include a description, affected versions, and
+a reproducing input (a BER byte sequence) where possible.
+
+## Hardening notes for callers
+
+When decoding untrusted data, keep the default limits in place or set your own:
+
+- `MaxPacketLengthBytes` bounds the size of any single decoded packet.
+- `MaxNestingDepth` bounds recursion into constructed packets.
+
+Setting either to `0` disables that limit and is not recommended for untrusted
+input.

--- a/ber.go
+++ b/ber.go
@@ -484,7 +484,14 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 		p.Data.Write(content)
 	}
 
-	return p, read, err
+	// A content-parse failure (invalid REAL, UTF-8, OID, over-long INTEGER,
+	// etc.) yields no usable packet; return nil so callers never see a
+	// partially-populated packet alongside an error.
+	if err != nil {
+		return nil, read, err
+	}
+
+	return p, read, nil
 }
 
 func isPrintableString(val string) error {
@@ -627,7 +634,9 @@ func NewLDAPBoolean(classType Class, tagType Type, tag Tag, value bool, descript
 	return p
 }
 
-func NewInteger(classType Class, tagType Type, tag Tag, value interface{}, description string) *Packet {
+// NewIntegerErr behaves like [NewInteger] but returns an error instead of
+// panicking when value is not a supported signed or unsigned integer type.
+func NewIntegerErr(classType Class, tagType Type, tag Tag, value interface{}, description string) (*Packet, error) {
 	p := Encode(classType, tagType, tag, nil, description)
 
 	p.Value = value
@@ -655,9 +664,19 @@ func NewInteger(classType Class, tagType Type, tag Tag, value interface{}, descr
 		p.Data.Write(encodeInteger(int64(v)))
 	default:
 		// TODO : add support for big.Int ?
-		panic(fmt.Sprintf("Invalid type %T, expected {u|}int{64|32|16|8}", v))
+		return nil, fmt.Errorf("invalid type %T, expected {u|}int{64|32|16|8}", v)
 	}
 
+	return p, nil
+}
+
+// NewInteger builds an INTEGER packet. It panics if value is not a signed or
+// unsigned integer type; use [NewIntegerErr] to receive an error instead.
+func NewInteger(classType Class, tagType Type, tag Tag, value interface{}, description string) *Packet {
+	p, err := NewIntegerErr(classType, tagType, tag, value, description)
+	if err != nil {
+		panic(err.Error())
+	}
 	return p
 }
 
@@ -683,7 +702,9 @@ func NewGeneralizedTime(classType Class, tagType Type, tag Tag, value time.Time,
 	return p
 }
 
-func NewReal(classType Class, tagType Type, tag Tag, value interface{}, description string) *Packet {
+// NewRealErr behaves like [NewReal] but returns an error instead of panicking
+// when value is not a float32 or float64.
+func NewRealErr(classType Class, tagType Type, tag Tag, value interface{}, description string) (*Packet, error) {
 	p := Encode(classType, tagType, tag, nil, description)
 
 	switch v := value.(type) {
@@ -692,43 +713,79 @@ func NewReal(classType Class, tagType Type, tag Tag, value interface{}, descript
 	case float32:
 		p.Data.Write(encodeFloat(float64(v)))
 	default:
-		panic(fmt.Sprintf("Invalid type %T, expected float{64|32}", v))
+		return nil, fmt.Errorf("invalid type %T, expected float{64|32}", v)
+	}
+	return p, nil
+}
+
+// NewReal builds a REAL packet. It panics if value is not a float32 or float64;
+// use [NewRealErr] to receive an error instead.
+func NewReal(classType Class, tagType Type, tag Tag, value interface{}, description string) *Packet {
+	p, err := NewRealErr(classType, tagType, tag, value, description)
+	if err != nil {
+		panic(err.Error())
 	}
 	return p
 }
 
+// NewOIDErr behaves like [NewOID] but returns an error instead of panicking on
+// a non-string value or returning nil on an invalid OID string.
+func NewOIDErr(classType Class, tagType Type, tag Tag, value interface{}, description string) (*Packet, error) {
+	p := Encode(classType, tagType, tag, nil, description)
+
+	v, ok := value.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid type %T, expected string", value)
+	}
+	encoded, err := encodeOID(v)
+	if err != nil {
+		return nil, err
+	}
+	p.Value = v
+	p.Data.Write(encoded)
+	return p, nil
+}
+
+// Deprecated: NewOID panics on a non-string value and returns nil on an invalid
+// OID string. Use [NewOIDErr], which reports both as errors.
 func NewOID(classType Class, tagType Type, tag Tag, value interface{}, description string) *Packet {
-	p := Encode(classType, tagType, tag, nil, description)
-
-	switch v := value.(type) {
-	case string:
-		encoded, err := encodeOID(v)
-		if err != nil {
-			return nil
+	p, err := NewOIDErr(classType, tagType, tag, value, description)
+	if err != nil {
+		if _, ok := value.(string); !ok {
+			panic(err.Error())
 		}
-		p.Value = v
-		p.Data.Write(encoded)
-		// TODO: support []int already ?
-	default:
-		panic(fmt.Sprintf("Invalid type %T, expected float{64|32}", v))
+		return nil
 	}
 	return p
 }
 
-func NewRelativeOID(classType Class, tagType Type, tag Tag, value interface{}, description string) *Packet {
+// NewRelativeOIDErr behaves like [NewRelativeOID] but returns an error instead
+// of panicking on a non-string value or returning nil on invalid input.
+func NewRelativeOIDErr(classType Class, tagType Type, tag Tag, value interface{}, description string) (*Packet, error) {
 	p := Encode(classType, tagType, tag, nil, description)
 
-	switch v := value.(type) {
-	case string:
-		encoded, err := encodeRelativeOID(v)
-		if err != nil {
-			return nil
+	v, ok := value.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid type %T, expected string", value)
+	}
+	encoded, err := encodeRelativeOID(v)
+	if err != nil {
+		return nil, err
+	}
+	p.Value = v
+	p.Data.Write(encoded)
+	return p, nil
+}
+
+// Deprecated: NewRelativeOID panics on a non-string value and returns nil on
+// invalid input. Use [NewRelativeOIDErr], which reports both as errors.
+func NewRelativeOID(classType Class, tagType Type, tag Tag, value interface{}, description string) *Packet {
+	p, err := NewRelativeOIDErr(classType, tagType, tag, value, description)
+	if err != nil {
+		if _, ok := value.(string); !ok {
+			panic(err.Error())
 		}
-		p.Value = v
-		p.Data.Write(encoded)
-		// TODO: support []int already ?
-	default:
-		panic(fmt.Sprintf("Invalid type %T, expected float{64|32}", v))
+		return nil
 	}
 	return p
 }
@@ -746,7 +803,7 @@ func encodeOID(oidString string) ([]byte, error) {
 		oid[i] = val
 	}
 	if len(oid) < 2 || oid[0] > 2 || (oid[0] < 2 && oid[1] >= 40) {
-		panic(fmt.Sprintf("invalid object identifier % d", oid)) // TODO: not elegant
+		return nil, fmt.Errorf("invalid object identifier %v", oid)
 	}
 	encoded := make([]byte, 0)
 

--- a/ber.go
+++ b/ber.go
@@ -790,24 +790,33 @@ func NewRelativeOID(classType Class, tagType Type, tag Tag, value interface{}, d
 	return p
 }
 
-// encodeOID takes a string representation of an OID and returns its DER-encoded byte slice along with any error.
-func encodeOID(oidString string) ([]byte, error) {
-	// Convert the string representation to an asn1.ObjectIdentifier
+// parseDottedInts splits a dotted-decimal OID string (e.g. "1.2.840") into its
+// integer arcs. label names the OID kind for error messages.
+func parseDottedInts(oidString, label string) ([]int, error) {
 	parts := strings.Split(oidString, ".")
 	oid := make([]int, len(parts))
 	for i, part := range parts {
 		val, err := strconv.Atoi(part)
 		if err != nil {
-			return nil, fmt.Errorf("invalid OID part '%s': %w", part, err)
+			return nil, fmt.Errorf("invalid %s part '%s': %w", label, part, err)
 		}
 		oid[i] = val
+	}
+	return oid, nil
+}
+
+// encodeOID takes a string representation of an OID and returns its DER-encoded byte slice along with any error.
+func encodeOID(oidString string) ([]byte, error) {
+	oid, err := parseDottedInts(oidString, "OID")
+	if err != nil {
+		return nil, err
 	}
 	if len(oid) < 2 || oid[0] > 2 || (oid[0] < 2 && oid[1] >= 40) {
 		return nil, fmt.Errorf("invalid object identifier %v", oid)
 	}
-	encoded := make([]byte, 0)
 
-	encoded = appendBase128Int(encoded[:0], int64(oid[0]*40+oid[1]))
+	// The first two arcs are combined into a single value: 40*arc0 + arc1.
+	encoded := appendBase128Int(nil, int64(oid[0]*40+oid[1]))
 	for i := 2; i < len(oid); i++ {
 		encoded = appendBase128Int(encoded, int64(oid[i]))
 	}
@@ -816,20 +825,14 @@ func encodeOID(oidString string) ([]byte, error) {
 }
 
 func encodeRelativeOID(oidString string) ([]byte, error) {
-	parts := strings.Split(oidString, ".")
-	oid := make([]int, len(parts))
-	for i, part := range parts {
-		val, err := strconv.Atoi(part)
-		if err != nil {
-			return nil, fmt.Errorf("invalid RELATIVE OID part '%s': %w", part, err)
-		}
-		oid[i] = val
+	oid, err := parseDottedInts(oidString, "RELATIVE OID")
+	if err != nil {
+		return nil, err
 	}
 
-	encoded := make([]byte, 0)
-
-	for i := 0; i < len(oid); i++ {
-		encoded = appendBase128Int(encoded, int64(oid[i]))
+	var encoded []byte
+	for _, arc := range oid {
+		encoded = appendBase128Int(encoded, int64(arc))
 	}
 
 	return encoded, nil
@@ -879,18 +882,33 @@ func OIDToString(oi []int) string {
 	return s.String()
 }
 
+// parseBase128Ints decodes successive base-128 integers from bytes[offset:]
+// into dst starting at index i, returning the index one past the last element
+// written (the total count when i started at 0).
+func parseBase128Ints(bytes []byte, offset int, dst []int, i int) (int, error) {
+	for offset < len(bytes) {
+		v, next, err := parseBase128Int(bytes, offset)
+		if err != nil {
+			return i, err
+		}
+		dst[i] = v
+		offset = next
+		i++
+	}
+	return i, nil
+}
+
 // parseObjectIdentifier parses an OBJECT IDENTIFIER from the given bytes and
 // returns it. An object identifier is a sequence of variable length integers
 // that are assigned in a hierarchy.
-func parseObjectIdentifier(bytes []byte) (s []int, err error) {
+func parseObjectIdentifier(bytes []byte) ([]int, error) {
 	if len(bytes) == 0 {
-		err = errors.New("zero length OBJECT IDENTIFIER")
-		return
+		return nil, errors.New("zero length OBJECT IDENTIFIER")
 	}
 
 	// In the worst case, we get two elements from the first byte (which is
 	// encoded differently) and then every varint is a single byte long.
-	s = make([]int, len(bytes)+1)
+	s := make([]int, len(bytes)+1)
 
 	// The first varint is 40*value1 + value2:
 	// According to this packing, value1 can take the values 0, 1 and 2 only.
@@ -898,7 +916,7 @@ func parseObjectIdentifier(bytes []byte) (s []int, err error) {
 	// then there are no restrictions on value2.
 	v, offset, err := parseBase128Int(bytes, 0)
 	if err != nil {
-		return
+		return nil, err
 	}
 	if v < 80 {
 		s[0] = v / 40
@@ -908,37 +926,25 @@ func parseObjectIdentifier(bytes []byte) (s []int, err error) {
 		s[1] = v - 80
 	}
 
-	i := 2
-	for ; offset < len(bytes); i++ {
-		v, offset, err = parseBase128Int(bytes, offset)
-		if err != nil {
-			return
-		}
-		s[i] = v
+	i, err := parseBase128Ints(bytes, offset, s, 2)
+	if err != nil {
+		return nil, err
 	}
-	s = s[0:i]
-	return
+	return s[:i], nil
 }
 
-func parseRelativeObjectIdentifier(bytes []byte) (s []int, err error) {
+func parseRelativeObjectIdentifier(bytes []byte) ([]int, error) {
 	if len(bytes) == 0 {
-		err = errors.New("zero length RELATIVE OBJECT IDENTIFIER")
-		return
+		return nil, errors.New("zero length RELATIVE OBJECT IDENTIFIER")
 	}
 
-	s = make([]int, len(bytes)+1)
+	s := make([]int, len(bytes)+1)
 
-	var v, offset int
-	i := 0
-	for ; offset < len(bytes); i++ {
-		v, offset, err = parseBase128Int(bytes, offset)
-		if err != nil {
-			return
-		}
-		s[i] = v
+	i, err := parseBase128Ints(bytes, 0, s, 0)
+	if err != nil {
+		return nil, err
 	}
-	s = s[0:i]
-	return
+	return s[:i], nil
 }
 
 // parseBase128Int parses a base-128 encoded int from the given offset in the

--- a/ber.go
+++ b/ber.go
@@ -24,8 +24,12 @@ var MaxNestingDepth int = 1000
 
 type Packet struct {
 	Identifier
-	Value       interface{}
-	ByteValue   []byte
+	Value     interface{}
+	ByteValue []byte
+	// Data holds the raw content octets of a primitive packet. For a
+	// constructed packet it is NOT populated after decoding or AppendChild --
+	// the content is derived lazily from Children by Bytes(). Do not read Data
+	// on a constructed packet; walk Children or call Bytes() instead.
 	Data        *bytes.Buffer
 	Children    []*Packet
 	Description string
@@ -197,12 +201,26 @@ func DescribePacket(p *Packet) string {
 		description = p.Description + ": "
 	}
 
-	dataLen := 0
-	if p.Data != nil {
-		dataLen = p.Data.Len()
+	return fmt.Sprintf("%s(%s, %s, %s) Len=%d %q", description, classStr, tagTypeStr, tagStr, p.contentLength(), value)
+}
+
+// contentLength reports the length in bytes of the packet's BER content -- the
+// value that follows the length octets -- computed without materializing the
+// encoded form. For a constructed packet this recurses through its children.
+func (p *Packet) contentLength() int {
+	if len(p.Children) == 0 {
+		if p.Data == nil {
+			return 0
+		}
+		return p.Data.Len()
 	}
 
-	return fmt.Sprintf("%s(%s, %s, %s) Len=%d %q", description, classStr, tagTypeStr, tagStr, dataLen, value)
+	n := 0
+	for _, child := range p.Children {
+		c := child.contentLength()
+		n += len(encodeIdentifier(child.Identifier)) + len(encodeLength(c)) + c
+	}
+	return n
 }
 
 func printPacket(out io.Writer, p *Packet, indent int, printBytes bool) {
@@ -486,18 +504,39 @@ func isPrintableString(val string) error {
 	return nil
 }
 
+// Bytes returns the BER encoding of the packet and, for a constructed packet,
+// its children. It is recomputed on each call (not cached), so avoid calling it
+// repeatedly on large packets in hot paths.
 func (p *Packet) Bytes() []byte {
 	var out bytes.Buffer
 
 	out.Write(encodeIdentifier(p.Identifier))
-	out.Write(encodeLength(p.Data.Len()))
-	out.Write(p.Data.Bytes())
+
+	if len(p.Children) == 0 {
+		// Primitive packet (or an empty constructed one): the content is p.Data.
+		out.Write(encodeLength(p.Data.Len()))
+		out.Write(p.Data.Bytes())
+		return out.Bytes()
+	}
+
+	// Constructed packet: serialize children on demand. We deliberately do not
+	// cache this in p.Data (see AppendChild): doing so at every level made a
+	// decoded tree cost O(depth x subtree) memory.
+	var content bytes.Buffer
+	for _, child := range p.Children {
+		content.Write(child.Bytes())
+	}
+	out.Write(encodeLength(content.Len()))
+	out.Write(content.Bytes())
 
 	return out.Bytes()
 }
 
 func (p *Packet) AppendChild(child *Packet) {
-	p.Data.Write(child.Bytes())
+	// Children are serialized lazily by Bytes(); we intentionally do not copy
+	// the child's encoded form into p.Data. Eager buffering made every ancestor
+	// retain a full copy of its subtree -- an O(depth x subtree) memory
+	// amplification that a deeply-nested packet could exploit.
 	p.Children = append(p.Children, child)
 }
 

--- a/ber.go
+++ b/ber.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"reflect"
@@ -181,7 +180,6 @@ func PrintPacket(p *Packet) {
 // If the packet is a sequence, use `printPacket()`, or browse
 // sequence yourself.
 func DescribePacket(p *Packet) string {
-
 	classStr := ClassMap[p.ClassType]
 
 	tagTypeStr := TypeMap[p.TagType]
@@ -199,7 +197,12 @@ func DescribePacket(p *Packet) string {
 		description = p.Description + ": "
 	}
 
-	return fmt.Sprintf("%s(%s, %s, %s) Len=%d %q", description, classStr, tagTypeStr, tagStr, p.Data.Len(), value)
+	dataLen := 0
+	if p.Data != nil {
+		dataLen = p.Data.Len()
+	}
+
+	return fmt.Sprintf("%s(%s, %s, %s) Len=%d %q", description, classStr, tagTypeStr, tagStr, dataLen, value)
 }
 
 func printPacket(out io.Writer, p *Packet, indent int, printBytes bool) {
@@ -236,7 +239,7 @@ func DecodeString(data []byte) string {
 func ParseInt64(bytes []byte) (ret int64, err error) {
 	if len(bytes) > 8 {
 		// We'll overflow an int64 in this case.
-		err = fmt.Errorf("integer too large")
+		err = errors.New("integer too large")
 		return
 	}
 	for bytesRead := 0; bytesRead < len(bytes); bytesRead++ {
@@ -282,7 +285,10 @@ func int64Length(i int64) (numBytes int) {
 // DecodePacket decodes the given bytes into a single Packet
 // If a decode error is encountered, nil is returned.
 func DecodePacket(data []byte) *Packet {
-	p, _, _ := readPacket(bytes.NewBuffer(data), 0)
+	p, _, err := readPacket(bytes.NewBuffer(data), 0)
+	if err != nil {
+		return nil
+	}
 
 	return p
 }
@@ -368,7 +374,7 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 	if length > 0 {
 		// Read the content and limit it to the parsed length.
 		// If the content is less than the length, we return an EOF error.
-		content, err = ioutil.ReadAll(io.LimitReader(reader, int64(length)))
+		content, err = io.ReadAll(io.LimitReader(reader, int64(length)))
 		if err == nil && len(content) < int(length) {
 			err = io.EOF
 		}
@@ -388,11 +394,12 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 		switch p.Tag {
 		case TagEOC:
 		case TagBoolean:
-			val, _ := ParseInt64(content)
+			var val int64
+			val, err = ParseInt64(content)
 
 			p.Value = val != 0
 		case TagInteger:
-			p.Value, _ = ParseInt64(content)
+			p.Value, err = ParseInt64(content)
 		case TagBitString:
 		case TagOctetString:
 			// the actual string encoding is not known here
@@ -401,8 +408,8 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 			p.Value = DecodeString(content)
 		case TagNULL:
 		case TagObjectIdentifier:
-			oid, err := parseObjectIdentifier(content)
-			if err == nil {
+			var oid []int
+			if oid, err = parseObjectIdentifier(content); err == nil {
 				p.Value = OIDToString(oid)
 			}
 		case TagObjectDescriptor:
@@ -410,7 +417,7 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 		case TagRealFloat:
 			p.Value, err = ParseReal(content)
 		case TagEnumerated:
-			p.Value, _ = ParseInt64(content)
+			p.Value, err = ParseInt64(content)
 		case TagEmbeddedPDV:
 		case TagUTF8String:
 			val := DecodeString(content)
@@ -420,8 +427,8 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 				p.Value = val
 			}
 		case TagRelativeOID:
-			oid, err := parseRelativeObjectIdentifier(content)
-			if err == nil {
+			var oid []int
+			if oid, err = parseRelativeObjectIdentifier(content); err == nil {
 				p.Value = OIDToString(oid)
 			}
 		case TagSequence:
@@ -437,7 +444,7 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 		case TagIA5String:
 			val := DecodeString(content)
 			for i, c := range val {
-				if c >= 0x7F {
+				if c > 0x7F {
 					err = fmt.Errorf("invalid character for IA5String at pos %d: %c", i, c)
 					break
 				}
@@ -510,7 +517,8 @@ func Encode(classType Class, tagType Type, tag Tag, value interface{}, descripti
 	if value != nil {
 		v := reflect.ValueOf(value)
 
-		if classType == ClassUniversal {
+		switch classType {
+		case ClassUniversal:
 			switch tag {
 			case TagOctetString:
 				sv, ok := v.Interface().(string)
@@ -529,7 +537,7 @@ func Encode(classType Class, tagType Type, tag Tag, value interface{}, descripti
 					p.Data.Write(bv)
 				}
 			}
-		} else if classType == ClassContext {
+		case ClassContext:
 			switch tag {
 			case TagEnumerated:
 				bv, ok := v.Interface().([]byte)
@@ -657,7 +665,6 @@ func NewOID(classType Class, tagType Type, tag Tag, value interface{}, descripti
 	case string:
 		encoded, err := encodeOID(v)
 		if err != nil {
-			fmt.Printf("failed writing %v", err)
 			return nil
 		}
 		p.Value = v
@@ -676,7 +683,6 @@ func NewRelativeOID(classType Class, tagType Type, tag Tag, value interface{}, d
 	case string:
 		encoded, err := encodeRelativeOID(v)
 		if err != nil {
-			fmt.Printf("failed writing %v", err)
 			return nil
 		}
 		p.Value = v
@@ -694,8 +700,8 @@ func encodeOID(oidString string) ([]byte, error) {
 	parts := strings.Split(oidString, ".")
 	oid := make([]int, len(parts))
 	for i, part := range parts {
-		var val int
-		if _, err := fmt.Sscanf(part, "%d", &val); err != nil {
+		val, err := strconv.Atoi(part)
+		if err != nil {
 			return nil, fmt.Errorf("invalid OID part '%s': %w", part, err)
 		}
 		oid[i] = val
@@ -717,8 +723,8 @@ func encodeRelativeOID(oidString string) ([]byte, error) {
 	parts := strings.Split(oidString, ".")
 	oid := make([]int, len(parts))
 	for i, part := range parts {
-		var val int
-		if _, err := fmt.Sscanf(part, "%d", &val); err != nil {
+		val, err := strconv.Atoi(part)
+		if err != nil {
 			return nil, fmt.Errorf("invalid RELATIVE OID part '%s': %w", part, err)
 		}
 		oid[i] = val
@@ -748,6 +754,7 @@ func appendBase128Int(dst []byte, n int64) []byte {
 
 	return dst
 }
+
 func base128IntLength(n int64) int {
 	if n == 0 {
 		return 1
@@ -781,7 +788,7 @@ func OIDToString(oi []int) string {
 // that are assigned in a hierarchy.
 func parseObjectIdentifier(bytes []byte) (s []int, err error) {
 	if len(bytes) == 0 {
-		err = fmt.Errorf("zero length OBJECT IDENTIFIER")
+		err = errors.New("zero length OBJECT IDENTIFIER")
 		return
 	}
 
@@ -819,7 +826,7 @@ func parseObjectIdentifier(bytes []byte) (s []int, err error) {
 
 func parseRelativeObjectIdentifier(bytes []byte) (s []int, err error) {
 	if len(bytes) == 0 {
-		err = fmt.Errorf("zero length RELATIVE OBJECT IDENTIFIER")
+		err = errors.New("zero length RELATIVE OBJECT IDENTIFIER")
 		return
 	}
 
@@ -847,7 +854,7 @@ func parseBase128Int(bytes []byte, initOffset int) (ret, offset int, err error) 
 		// 5 * 7 bits per byte == 35 bits of data
 		// Thus the representation is either non-minimal or too large for an int32
 		if shifted == 5 {
-			err = fmt.Errorf("base 128 integer too large")
+			err = errors.New("base 128 integer too large")
 			return
 		}
 		ret64 <<= 7
@@ -855,7 +862,7 @@ func parseBase128Int(bytes []byte, initOffset int) (ret, offset int, err error) 
 		// integers should be minimally encoded, so the leading octet should
 		// never be 0x80
 		if shifted == 0 && b == 0x80 {
-			err = fmt.Errorf("integer is not minimally encoded")
+			err = errors.New("integer is not minimally encoded")
 			return
 		}
 		ret64 |= int64(b & 0x7f)
@@ -864,11 +871,11 @@ func parseBase128Int(bytes []byte, initOffset int) (ret, offset int, err error) 
 			ret = int(ret64)
 			// Ensure that the returned value fits in an int on all platforms
 			if ret64 > math.MaxInt32 {
-				err = fmt.Errorf("base 128 integer too large")
+				err = errors.New("base 128 integer too large")
 			}
 			return
 		}
 	}
-	err = fmt.Errorf("truncated base 128 integer")
+	err = errors.New("truncated base 128 integer")
 	return
 }

--- a/constructors_test.go
+++ b/constructors_test.go
@@ -1,0 +1,75 @@
+package ber
+
+import "testing"
+
+func TestNewIntegerErr(t *testing.T) {
+	if _, err := NewIntegerErr(ClassUniversal, TypePrimitive, TagInteger, 42, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := NewIntegerErr(ClassUniversal, TypePrimitive, TagInteger, "nope", ""); err == nil {
+		t.Fatal("expected error for non-integer value")
+	}
+}
+
+func TestNewRealErr(t *testing.T) {
+	if _, err := NewRealErr(ClassUniversal, TypePrimitive, TagRealFloat, 1.5, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := NewRealErr(ClassUniversal, TypePrimitive, TagRealFloat, 3, ""); err == nil {
+		t.Fatal("expected error for non-float value")
+	}
+}
+
+func TestNewOIDErr(t *testing.T) {
+	p, err := NewOIDErr(ClassUniversal, TypePrimitive, TagObjectIdentifier, "1.2.840.113549", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	decoded, err := DecodePacketErr(p.Bytes())
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.Value != "1.2.840.113549" {
+		t.Fatalf("round-trip mismatch: got %v", decoded.Value)
+	}
+
+	// Structurally invalid OID string: an error, not a panic.
+	if _, err := NewOIDErr(ClassUniversal, TypePrimitive, TagObjectIdentifier, "1", ""); err == nil {
+		t.Fatal("expected error for structurally invalid OID")
+	}
+	// Non-string value: an error, not a panic.
+	if _, err := NewOIDErr(ClassUniversal, TypePrimitive, TagObjectIdentifier, 123, ""); err == nil {
+		t.Fatal("expected error for non-string value")
+	}
+}
+
+// TestNewOIDNoPanicOnInvalidString confirms the deprecated NewOID returns nil
+// (rather than panicking) on a structurally invalid OID string, now that
+// encodeOID returns an error instead of panicking.
+func TestNewOIDNoPanicOnInvalidString(t *testing.T) {
+	if p := NewOID(ClassUniversal, TypePrimitive, TagObjectIdentifier, "1", ""); p != nil {
+		t.Fatalf("expected nil for invalid OID string, got %v", p)
+	}
+}
+
+func TestNewRelativeOIDErr(t *testing.T) {
+	if _, err := NewRelativeOIDErr(ClassUniversal, TypePrimitive, TagRelativeOID, "8571.3.2", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := NewRelativeOIDErr(ClassUniversal, TypePrimitive, TagRelativeOID, "not.a.number", ""); err == nil {
+		t.Fatal("expected error for invalid relative OID")
+	}
+}
+
+// TestDecodePacketErrNilOnContentError confirms a content-parse failure yields
+// a nil packet alongside the error, never a partially-populated one. The bytes
+// are a UTF8String (0x0c) of length 1 containing invalid UTF-8 (0xff).
+func TestDecodePacketErrNilOnContentError(t *testing.T) {
+	p, err := DecodePacketErr([]byte{0x0c, 0x01, 0xff})
+	if err == nil {
+		t.Fatal("expected error for invalid UTF-8")
+	}
+	if p != nil {
+		t.Fatalf("expected nil packet on error, got %v", p)
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,13 @@
+// Package ber implements ASN.1 Basic Encoding Rules (BER), the encoding used by
+// protocols such as LDAP (RFC 4511).
+//
+// A decoded document is represented as a tree of [Packet] values. Decode bytes
+// with [DecodePacketErr], or stream from an [io.Reader] with [ReadPacket]; build
+// packets to encode with the New* constructors and serialize them with
+// [Packet.Bytes].
+//
+// The decoder is written to accept untrusted input: the [MaxPacketLengthBytes]
+// and [MaxNestingDepth] package variables bound allocation and recursion. Prefer
+// [DecodePacketErr] over [DecodePacket], which reports failure only by returning
+// nil.
+package ber

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,22 @@
+package ber_test
+
+import (
+	"fmt"
+
+	ber "github.com/go-asn1-ber/asn1-ber"
+)
+
+// ExampleDecodePacketErr encodes a SEQUENCE containing a single OCTET STRING,
+// serializes it to BER bytes, and decodes it back into a packet tree.
+func ExampleDecodePacketErr() {
+	seq := ber.NewSequence("greeting")
+	seq.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "Hello, world", ""))
+
+	packet, err := ber.DecodePacketErr(seq.Bytes())
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(packet.Children[0].Value)
+	// Output: Hello, world
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-asn1-ber/asn1-ber
 
-go 1.13
+go 1.22

--- a/header_test.go
+++ b/header_test.go
@@ -104,7 +104,8 @@ func TestReadHeader(t *testing.T) {
 		}
 
 		if identifier.ClassType != tc.ExpectedIdentifier.ClassType {
-			t.Errorf("%s: expected class type %d (%s), got %d (%s)", k,
+			t.Errorf(
+				"%s: expected class type %d (%s), got %d (%s)", k,
 				tc.ExpectedIdentifier.ClassType,
 				ClassMap[tc.ExpectedIdentifier.ClassType],
 				identifier.ClassType,
@@ -112,7 +113,8 @@ func TestReadHeader(t *testing.T) {
 			)
 		}
 		if identifier.TagType != tc.ExpectedIdentifier.TagType {
-			t.Errorf("%s: expected tag type %d (%s), got %d (%s)", k,
+			t.Errorf(
+				"%s: expected tag type %d (%s), got %d (%s)", k,
 				tc.ExpectedIdentifier.TagType,
 				TypeMap[tc.ExpectedIdentifier.TagType],
 				identifier.TagType,
@@ -120,7 +122,8 @@ func TestReadHeader(t *testing.T) {
 			)
 		}
 		if identifier.Tag != tc.ExpectedIdentifier.Tag {
-			t.Errorf("%s: expected tag %d (%s), got %d (%s)", k,
+			t.Errorf(
+				"%s: expected tag %d (%s), got %d (%s)", k,
 				tc.ExpectedIdentifier.Tag,
 				tagMap[tc.ExpectedIdentifier.Tag],
 				identifier.Tag,

--- a/identifier_test.go
+++ b/identifier_test.go
@@ -201,7 +201,8 @@ func TestReadIdentifier(t *testing.T) {
 		}
 
 		if identifier.ClassType != tc.ExpectedIdentifier.ClassType {
-			t.Errorf("%s: expected class type %d (%s), got %d (%s)", k,
+			t.Errorf(
+				"%s: expected class type %d (%s), got %d (%s)", k,
 				tc.ExpectedIdentifier.ClassType,
 				ClassMap[tc.ExpectedIdentifier.ClassType],
 				identifier.ClassType,
@@ -209,7 +210,8 @@ func TestReadIdentifier(t *testing.T) {
 			)
 		}
 		if identifier.TagType != tc.ExpectedIdentifier.TagType {
-			t.Errorf("%s: expected tag type %d (%s), got %d (%s)", k,
+			t.Errorf(
+				"%s: expected tag type %d (%s), got %d (%s)", k,
 				tc.ExpectedIdentifier.TagType,
 				TypeMap[tc.ExpectedIdentifier.TagType],
 				identifier.TagType,
@@ -217,7 +219,8 @@ func TestReadIdentifier(t *testing.T) {
 			)
 		}
 		if identifier.Tag != tc.ExpectedIdentifier.Tag {
-			t.Errorf("%s: expected tag %d (%s), got %d (%s)", k,
+			t.Errorf(
+				"%s: expected tag %d (%s), got %d (%s)", k,
 				tc.ExpectedIdentifier.Tag,
 				tagMap[tc.ExpectedIdentifier.Tag],
 				identifier.Tag,

--- a/lazy_test.go
+++ b/lazy_test.go
@@ -1,0 +1,55 @@
+package ber
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestLazyDeepNestingRoundTrip builds a deeply-nested constructed packet and
+// verifies it round-trips. Before lazy serialization each ancestor retained a
+// full copy of its subtree (O(depth x subtree) memory); this exercises the
+// depth path and confirms the encoding is unchanged.
+func TestLazyDeepNestingRoundTrip(t *testing.T) {
+	const depth = 500
+
+	root := NewSequence("root")
+	cur := root
+	for i := 0; i < depth; i++ {
+		child := NewSequence("nested")
+		cur.AppendChild(child)
+		cur = child
+	}
+	cur.AppendChild(NewString(ClassUniversal, TypePrimitive, TagOctetString, "leaf", ""))
+
+	encoded := root.Bytes()
+
+	decoded, err := DecodePacketErr(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if !bytes.Equal(decoded.Bytes(), encoded) {
+		t.Fatalf("round-trip mismatch: re-encoded bytes differ from source")
+	}
+}
+
+// TestLazyAppendChildReflectsLaterMutation verifies Bytes() reflects a child
+// appended after an intermediate AppendChild. The previous eager-buffering
+// implementation snapshotted the child into the parent's Data at AppendChild
+// time and would have missed the later grandchild.
+func TestLazyAppendChildReflectsLaterMutation(t *testing.T) {
+	parent := NewSequence("parent")
+	child := NewSequence("child")
+	parent.AppendChild(child)
+
+	// Append to the child after it was already appended to the parent.
+	child.AppendChild(NewString(ClassUniversal, TypePrimitive, TagOctetString, "late", ""))
+
+	want := NewSequence("parent")
+	wantChild := NewSequence("child")
+	wantChild.AppendChild(NewString(ClassUniversal, TypePrimitive, TagOctetString, "late", ""))
+	want.AppendChild(wantChild)
+
+	if got := parent.Bytes(); !bytes.Equal(got, want.Bytes()) {
+		t.Fatalf("parent.Bytes() did not reflect a child appended after AppendChild\n got: %x\nwant: %x", got, want.Bytes())
+	}
+}

--- a/length.go
+++ b/length.go
@@ -56,15 +56,18 @@ func readLength(reader io.Reader) (length int, read int, err error) {
 			length64 |= int64(b)
 		}
 
+		// A negative accumulator means the top bit is set, i.e. the length
+		// exceeds MaxInt64 -- far larger than we could ever read.
+		if length64 < 0 {
+			return 0, read, errors.New("long-form length overflow")
+		}
+
 		// Cast to a platform-specific integer
 		length = int(length64)
 		// Ensure we didn't overflow
 		if int64(length) != length64 {
 			return 0, read, errors.New("long-form length overflow")
 		}
-
-	default:
-		return 0, read, errors.New("invalid length byte")
 	}
 
 	return length, read, nil

--- a/real.go
+++ b/real.go
@@ -131,7 +131,7 @@ func parseDecimalFloat(v []byte) (val float64, err error) {
 		iVal, err = strconv.ParseInt(strings.TrimLeft(string(v[1:]), " "), 10, 64)
 		val = float64(iVal)
 	case 0x02, 0x03: // NR form 2, 3
-		val, err = strconv.ParseFloat(strings.Replace(strings.TrimLeft(string(v[1:]), " "), ",", ".", -1), 64)
+		val, err = strconv.ParseFloat(strings.ReplaceAll(strings.TrimLeft(string(v[1:]), " "), ",", "."), 64)
 	default:
 		err = errors.New("incorrect NR form")
 	}

--- a/real_test.go
+++ b/real_test.go
@@ -34,7 +34,7 @@ func TestRealBinaryDecodingTC10(t *testing.T) {
 	// This is the content of tests/tc10.ber. The orignal test suite would emit a
 	// "Needlessly long format" warning which we don't care about.
 	dec, err := DecodePacketErr([]byte{0x09, 0x07, 0x83, 0x04, 0xff, 0xff, 0xff, 0xfb, 0x05})
-	var expected float64 = 0.156250
+	expected := 0.156250
 	if err != nil {
 		t.Errorf("Failed to decode: %s", err)
 	}

--- a/suite_test.go
+++ b/suite_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 )
 
@@ -45,10 +45,10 @@ var testCases = []struct {
 	// Integers
 	{File: "tests/tc18.ber", Error: ""},
 	{File: "tests/tc19.ber", Error: errEOF},
-	{File: "tests/tc20.ber", Error: ""},
+	{File: "tests/tc20.ber", Error: "integer too large"}, // 9-byte INTEGER overflows int64
 	// Object identifiers
-	{File: "tests/tc21.ber", Error: ""},
-	{File: "tests/tc22.ber", Error: ""},
+	{File: "tests/tc21.ber", Error: "integer is not minimally encoded"}, // non-minimal base-128 arc
+	{File: "tests/tc22.ber", Error: "base 128 integer too large"},       // oversized base-128 arc
 	{File: "tests/tc23.ber", Error: errEOF},
 	{File: "tests/tc24.ber", Error: ""},
 	// Booleans
@@ -81,7 +81,7 @@ var testCases = []struct {
 	{File: "tests/tc47.ber", Error: "eoc child not allowed with definite length"},
 	{File: "tests/tc48.ber", Error: "", IndefiniteEncoding: true}, // Error: "Using of more than 7 "unused bits" in BIT STRING with constrictive encoding form"
 	{File: "tests/tc49.ber", Error: ""},
-	{File: "tests/tc50.ber", Error: is64bit("length cannot be less than -1", "long-form length overflow")},
+	{File: "tests/tc50.ber", Error: "long-form length overflow"},
 	{File: "tests/tc51.ber", Error: is64bit(fmt.Sprintf("length 206966894640 greater than maximum %v", MaxPacketLengthBytes), "long-form length overflow")},
 }
 
@@ -99,7 +99,7 @@ func TestSuiteDecodePacket(t *testing.T) {
 	for _, tc := range testCases {
 		file := tc.File
 
-		dataIn, err := ioutil.ReadFile(file)
+		dataIn, err := os.ReadFile(file)
 		if err != nil {
 			t.Errorf("%s: %v", file, err)
 			continue
@@ -149,7 +149,7 @@ func TestSuiteReadPacket(t *testing.T) {
 	for _, tc := range testCases {
 		file := tc.File
 
-		dataIn, err := ioutil.ReadFile(file)
+		dataIn, err := os.ReadFile(file)
 		if err != nil {
 			t.Errorf("%s: %v", file, err)
 			continue

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# Conformance test fixtures
+
+The `tc*.ber` files are BER-encoded inputs from the Strozhevsky free ASN.1 test
+suite, used by `TestSuiteDecodePacket` / `TestSuiteReadPacket` in
+`../suite_test.go` to exercise the decoder against well-formed and deliberately
+malformed encodings.
+
+- Descriptions: <http://www.strozhevsky.com/free_docs/free_asn1_testsuite_descr.pdf>
+- Original archive: <http://www.strozhevsky.com/free_docs/TEST_SUITE.zip>
+
+Each fixture's expected decode outcome (success, expected error string, or
+abnormal/indefinite re-encoding) is recorded in the `testCases` table in
+`../suite_test.go`.

--- a/util.go
+++ b/util.go
@@ -3,12 +3,14 @@ package ber
 import "io"
 
 func readByte(reader io.Reader) (byte, error) {
-	bytes := make([]byte, 1)
-	_, err := io.ReadFull(reader, bytes)
-	if err != nil {
+	if br, ok := reader.(io.ByteReader); ok {
+		return br.ReadByte()
+	}
+	var b [1]byte
+	if _, err := io.ReadFull(reader, b[:]); err != nil {
 		return 0, err
 	}
-	return bytes[0], nil
+	return b[0], nil
 }
 
 func unexpectedEOF(err error) error {


### PR DESCRIPTION
Addresses a full adversarial review of the decoder, encoder, CI, and docs. The
work is split into logically-scoped commits; the four fix/refactor commits each
landed only after an independent challenge review converged.

## Security / correctness fixes

- **Silently-swallowed decode errors** — OID / Relative-OID parse errors were
  dropped via a shadowed `err`, so `DecodePacketErr` reported success on a
  malformed OID (`Value == nil`). Over-long INTEGER/BOOLEAN/ENUMERATED silently
  decoded to `0`. IA5String rejected the valid `0x7F` (DEL). An 8-byte long-form
  length with the high bit set was mistaken for indefinite length. All are now
  handled correctly.
- **Memory-amplification DoS** — `AppendChild` buffered each child's serialized
  subtree into every ancestor's `Data`, so a deeply-nested packet (bounded only
  by `MaxNestingDepth`) could amplify ~1 MB of input into ~1 GB of allocation.
  `Bytes()` now serializes lazily; retained memory is O(input).
- `readPacket` no longer returns a partially-populated packet alongside an error.

## New APIs

`NewIntegerErr`, `NewRealErr`, `NewOIDErr`, `NewRelativeOIDErr` return errors
instead of panicking or returning nil; `encodeOID` returns an error instead of
panicking.

## Behavior changes (see CHANGELOG.md)

- Requires **Go 1.22+**.
- Constructed packets no longer populate the exported `Data` field after decode
  or `AppendChild` — read content via `Bytes()` or `Children`. (go-ldap v3.4.10
  was checked and is unaffected: it reads `Data` only on primitive packets.)
- `DecodePacket` returns `nil` on any decode error.
- `NewOID` / `NewRelativeOID` return `nil` instead of panicking on an invalid
  OID string, and are deprecated in favor of the `*Err` variants.
- The decoder now rejects malformed inputs it previously accepted (see the
  tc20/tc21/tc22/tc50 fixture-expectation updates).

## Modernization

- **CI**: `stable`/`oldstable` + 1.22-floor matrix (was 8 EOL versions),
  push-triggered, pinned action versions, committed `.golangci.yml`, added fuzz
  and govulncheck jobs and dependabot.
- **Code**: `io.ReadAll`, `errors.New`, `strconv.Atoi`, allocation-free
  `readByte`, deduped OID encode/parse.
- **Docs**: rewrote the stale README, added a package doc comment and runnable
  example, `SECURITY.md`, `CHANGELOG.md`, and `tests/README.md`.

## Verification

`go build`/`vet` clean · `go test -race` green (77.5% coverage) ·
`golangci-lint` 0 issues · fuzz clean · `govulncheck` clean.
