### PR TITLE
fix: enforce `MaxPacketLengthBytes` for constructed packets

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -345,9 +345,10 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 			contentRead += r
 			read += r
 
-			// Enforce the aggregate size limit for constructed packets
-			if MaxPacketLengthBytes > 0 && int64(read) > MaxPacketLengthBytes {
-				return nil, read, fmt.Errorf("length %d greater than maximum %d", read, MaxPacketLengthBytes)
+			// Enforce the aggregate size limit for constructed packets. Indefinite length declares
+			// no bound up front, so the content bytes are only known as they are read.
+			if MaxPacketLengthBytes > 0 && int64(contentRead) > MaxPacketLengthBytes {
+				return nil, read, fmt.Errorf("length %d greater than maximum %d", contentRead, MaxPacketLengthBytes)
 			}
 
 			// Test is this is the EOC marker for our packet

--- a/ber.go
+++ b/ber.go
@@ -308,6 +308,10 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 		return nil, read, err
 	}
 
+	if length != LengthIndefinite && MaxPacketLengthBytes > 0 && int64(length) > MaxPacketLengthBytes {
+		return nil, read, fmt.Errorf("length %d greater than maximum %d", length, MaxPacketLengthBytes)
+	}
+
 	p := &Packet{
 		Identifier: identifier,
 	}
@@ -341,6 +345,11 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 			contentRead += r
 			read += r
 
+			// Enforce the aggregate size limit for constructed packets
+			if MaxPacketLengthBytes > 0 && int64(read) > MaxPacketLengthBytes {
+				return nil, read, fmt.Errorf("length %d greater than maximum %d", read, MaxPacketLengthBytes)
+			}
+
 			// Test is this is the EOC marker for our packet
 			if isEOCPacket(child) {
 				if length == LengthIndefinite {
@@ -357,11 +366,6 @@ func readPacket(reader io.Reader, depth int) (*Packet, int, error) {
 
 	if length == LengthIndefinite {
 		return nil, read, errors.New("indefinite length used with primitive type")
-	}
-
-	// Read definite-length content
-	if MaxPacketLengthBytes > 0 && int64(length) > MaxPacketLengthBytes {
-		return nil, read, fmt.Errorf("length %d greater than maximum %d", length, MaxPacketLengthBytes)
 	}
 
 	var content []byte

--- a/ber_test.go
+++ b/ber_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -338,16 +339,46 @@ func TestMaxNestingDepthReadPacketUnlimited(t *testing.T) {
 	}
 }
 
+// nulls returns n bytes worth of NULL (0x05 0x00) primitives. n must be even.
+func nulls(n int) []byte {
+	if n%2 != 0 {
+		panic("nulls: n must be even")
+	}
+	buf := make([]byte, 0, n)
+	for i := 0; i < n/2; i++ {
+		buf = append(buf, 0x05, 0x00)
+	}
+	return buf
+}
+
+// buildDefinite wraps content in a definite-length packet with the given identifier byte.
+func buildDefinite(tag byte, content []byte) []byte {
+	out := append([]byte{tag}, encodeLength(len(content))...)
+	return append(out, content...)
+}
+
+// buildIndefinite wraps content in an indefinite-length packet terminated by an EOC marker.
+// The content size seen by the parser is len(content) + 2, counting the EOC.
+func buildIndefinite(tag byte, content []byte) []byte {
+	out := append([]byte{tag, 0x80}, content...)
+	return append(out, 0x00, 0x00) // EOC
+}
+
 // buildConstructedIndefinite builds an indefinite-length SEQUENCE containing children
 // NULL (0x05 0x00) primitives, terminated by an EOC marker.
 func buildConstructedIndefinite(children int) []byte {
-	var buf bytes.Buffer
-	buf.Write([]byte{0x30, 0x80}) // SEQUENCE, indefinite length
-	for i := 0; i < children; i++ {
-		buf.Write([]byte{0x05, 0x00}) // NULL, length 0
+	return buildIndefinite(0x30, nulls(children*2))
+}
+
+// buildNestedIndefinite builds depth nested indefinite-length SEQUENCEs, each level holding
+// perLevel NULL primitives alongside the next level down. Spreading the content across every
+// level means no single level exceeds a limit that the tree as a whole does.
+func buildNestedIndefinite(depth, perLevel int) []byte {
+	inner := buildIndefinite(0x30, nulls(perLevel*2))
+	for i := 1; i < depth; i++ {
+		inner = buildIndefinite(0x30, append(nulls(perLevel*2), inner...))
 	}
-	buf.Write([]byte{0x00, 0x00}) // EOC
-	return buf.Bytes()
+	return inner
 }
 
 func TestMaxPacketLengthBytes(t *testing.T) {
@@ -372,6 +403,16 @@ func TestMaxPacketLengthBytes(t *testing.T) {
 		{"definite over limit", 1024, []byte{0x30, 0x82, 0x20, 0x00}, 0, true},
 		{"within limit", 1024, buildConstructedIndefinite(10), 10, false},
 		{"unlimited", 0, buildConstructedIndefinite(5000), 5000, false},
+
+		// The limit counts content bytes, so a packet declaring exactly the limit is accepted
+		// and one declaring a single byte more is not — identically for both length forms.
+		{"definite primitive at limit", 1024, buildDefinite(0x04, make([]byte, 1024)), 0, false},
+		{"definite primitive over limit", 1024, buildDefinite(0x04, make([]byte, 1025)), 0, true},
+		{"definite constructed at limit", 1024, buildDefinite(0x30, nulls(1024)), 512, false},
+		{"definite constructed over limit", 1024, buildDefinite(0x30, nulls(1026)), 0, true},
+		// 1022 content bytes plus the 2-byte EOC lands exactly on the limit.
+		{"indefinite at limit", 1024, buildIndefinite(0x30, nulls(1022)), 511, false},
+		{"indefinite just over limit", 1024, buildIndefinite(0x30, nulls(1024)), 0, true},
 	}
 
 	for _, tt := range tests {
@@ -388,6 +429,86 @@ func TestMaxPacketLengthBytes(t *testing.T) {
 					t.Errorf("expected %d children, got %d", tt.wantChildren, len(p.Children))
 				}
 			})
+		}
+	}
+}
+
+func TestMaxPacketLengthBytesNested(t *testing.T) {
+	old := MaxPacketLengthBytes
+	defer func() { MaxPacketLengthBytes = old }()
+
+	decoders := map[string]func([]byte) (*Packet, error){
+		"DecodePacketErr": DecodePacketErr,
+		"ReadPacket":      func(b []byte) (*Packet, error) { return ReadPacket(bytes.NewReader(b)) },
+	}
+
+	// A definite SEQUENCE understating its length, followed by an oversized indefinite child.
+	// The outer header passes the limit check, so only the child's own accounting can stop it.
+	understatedOuter := append([]byte{0x30, 0x64}, buildIndefinite(0x30, nulls(1100))...)
+
+	// Definite children each well under the limit, but summing past it inside an indefinite parent.
+	var definiteChildren []byte
+	for i := 0; i < 4; i++ {
+		definiteChildren = append(definiteChildren, buildDefinite(0x04, make([]byte, 400))...)
+	}
+
+	tests := []struct {
+		name    string
+		limit   int64
+		data    []byte
+		wantErr bool
+	}{
+		// No level holds more than ~200 bytes of its own, so this only trips if a child's size
+		// propagates up into its ancestors' accounting.
+		{"aggregate across levels", 1024, buildNestedIndefinite(8, 100), true},
+		{"oversized indefinite inside definite", 1024, understatedOuter, true},
+		{"definite children summing over limit", 1024, buildIndefinite(0x30, definiteChildren), true},
+		{"unlimited", 0, buildNestedIndefinite(8, 100), false},
+	}
+
+	for _, tt := range tests {
+		for decName, decode := range decoders {
+			t.Run(tt.name+"/"+decName, func(t *testing.T) {
+				MaxPacketLengthBytes = tt.limit
+				_, err := decode(tt.data)
+				switch {
+				case tt.wantErr && err == nil:
+					t.Fatal("expected error, got nil")
+				case tt.wantErr && !strings.Contains(err.Error(), "greater than maximum"):
+					// Guard against passing for the wrong reason, e.g. a truncation error
+					t.Fatalf("expected a length limit error, got %v", err)
+				case !tt.wantErr && err != nil:
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestNestedIndefiniteWithinLimit(t *testing.T) {
+	old := MaxPacketLengthBytes
+	defer func() { MaxPacketLengthBytes = old }()
+
+	MaxPacketLengthBytes = 1024
+
+	const depth, perLevel = 4, 5
+
+	p, err := DecodePacketErr(buildNestedIndefinite(depth, perLevel))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Every level but the innermost holds perLevel NULLs plus the nested SEQUENCE
+	for level := 1; level <= depth; level++ {
+		want := perLevel + 1
+		if level == depth {
+			want = perLevel
+		}
+		if len(p.Children) != want {
+			t.Fatalf("level %d: expected %d children, got %d", level, want, len(p.Children))
+		}
+		if level < depth {
+			p = p.Children[perLevel]
 		}
 	}
 }

--- a/ber_test.go
+++ b/ber_test.go
@@ -337,3 +337,57 @@ func TestMaxNestingDepthReadPacketUnlimited(t *testing.T) {
 		t.Errorf("50 levels with MaxNestingDepth=0: unexpected error %v", err)
 	}
 }
+
+// buildConstructedIndefinite builds an indefinite-length SEQUENCE containing children
+// NULL (0x05 0x00) primitives, terminated by an EOC marker.
+func buildConstructedIndefinite(children int) []byte {
+	var buf bytes.Buffer
+	buf.Write([]byte{0x30, 0x80}) // SEQUENCE, indefinite length
+	for i := 0; i < children; i++ {
+		buf.Write([]byte{0x05, 0x00}) // NULL, length 0
+	}
+	buf.Write([]byte{0x00, 0x00}) // EOC
+	return buf.Bytes()
+}
+
+func TestMaxPacketLengthBytes(t *testing.T) {
+	old := MaxPacketLengthBytes
+	defer func() { MaxPacketLengthBytes = old }()
+
+	decoders := map[string]func([]byte) (*Packet, error){
+		"DecodePacketErr": DecodePacketErr,
+		"ReadPacket":      func(b []byte) (*Packet, error) { return ReadPacket(bytes.NewReader(b)) },
+	}
+
+	tests := []struct {
+		name         string
+		limit        int64
+		data         []byte
+		wantChildren int // ignored when wantErr
+		wantErr      bool
+	}{
+		// Indefinite length carries no declared bound; only the aggregate byte count catches it.
+		{"indefinite over limit", 1024, buildConstructedIndefinite(2000), 0, true},
+		// SEQUENCE declaring definite long-form length 0x2000 (8192) — rejected up front.
+		{"definite over limit", 1024, []byte{0x30, 0x82, 0x20, 0x00}, 0, true},
+		{"within limit", 1024, buildConstructedIndefinite(10), 10, false},
+		{"unlimited", 0, buildConstructedIndefinite(5000), 5000, false},
+	}
+
+	for _, tt := range tests {
+		for decName, decode := range decoders {
+			t.Run(tt.name+"/"+decName, func(t *testing.T) {
+				MaxPacketLengthBytes = tt.limit
+				p, err := decode(tt.data)
+				switch {
+				case tt.wantErr && err == nil:
+					t.Fatal("expected error, got nil")
+				case !tt.wantErr && err != nil:
+					t.Fatalf("unexpected error: %v", err)
+				case !tt.wantErr && len(p.Children) != tt.wantChildren:
+					t.Errorf("expected %d children, got %d", tt.wantChildren, len(p.Children))
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes an oversight with the `MaxPacketLengthBytes` check, as it allows an malicious LDAP server to bypass the limit by sending sequence with indefinite length.