### PR TITLE
fix: reject long-form definite lengths that wrap negative

### DIFF
--- a/ber_test.go
+++ b/ber_test.go
@@ -269,6 +269,19 @@ func buildNestedSequence(depth int) []byte {
 	return inner
 }
 
+func TestLongFormLengthSentinelCollision(t *testing.T) {
+	// A definite-form length of 2^64-1 must not be reinterpreted as indefinite form.
+	data := []byte{
+		0x30,                                                 // SEQUENCE, constructed
+		0x88, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // "length" = 2^64-1
+		0x05, 0x00, // NULL child
+		0x00, 0x00, // EOC
+	}
+	if _, err := DecodePacketErr(data); err == nil {
+		t.Error("expected error for definite-form length 2^64-1, got nil")
+	}
+}
+
 func TestMaxNestingDepth(t *testing.T) {
 	old := MaxNestingDepth
 	defer func() { MaxNestingDepth = old }()

--- a/length.go
+++ b/length.go
@@ -40,7 +40,7 @@ func readLength(reader io.Reader) (length int, read int, err error) {
 		}
 
 		// Accumulate into a 64-bit variable
-		var length64 int64
+		var length64 uint64
 		for i := 0; i < lengthBytes; i++ {
 			b, err = readByte(reader)
 			if err != nil {
@@ -53,13 +53,14 @@ func readLength(reader io.Reader) (length int, read int, err error) {
 
 			// x.600, 8.1.3.5
 			length64 <<= 8
-			length64 |= int64(b)
+			length64 |= uint64(b)
 		}
 
 		// Cast to a platform-specific integer
 		length = int(length64)
-		// Ensure we didn't overflow
-		if int64(length) != length64 {
+		// Ensure we didn't overflow or wrap negative. Length octets are unsigned
+		// (x.600, 8.1.3.5), so a negative result is unrepresentable, not indefinite.
+		if length < 0 || uint64(length) != length64 {
 			return 0, read, errors.New("long-form length overflow")
 		}
 

--- a/length_test.go
+++ b/length_test.go
@@ -80,6 +80,36 @@ func TestReadLength(t *testing.T) {
 			ExpectedLength:    math.MaxInt32,
 			ExpectedBytesRead: 5,
 		},
+		"long-definite-form all-ones (indefinite sentinel collision)": {
+			Data: []byte{
+				LengthLongFormBitmask | 8,
+				0xFF,
+				0xFF,
+				0xFF,
+				0xFF,
+				0xFF,
+				0xFF,
+				0xFF,
+				0xFF,
+			},
+			ExpectedBytesRead: 9,
+			ExpectedError:     "long-form length overflow",
+		},
+		"long-definite-form negative int64": {
+			Data: []byte{
+				LengthLongFormBitmask | 8,
+				0x80,
+				0x00,
+				0x00,
+				0x00,
+				0x00,
+				0x00,
+				0x00,
+				0x00,
+			},
+			ExpectedBytesRead: 9,
+			ExpectedError:     "long-form length overflow",
+		},
 		"long-definite-form max length (64-bit)": {
 			Data: []byte{
 				LengthLongFormBitmask | 8,

--- a/suite_test.go
+++ b/suite_test.go
@@ -81,7 +81,7 @@ var testCases = []struct {
 	{File: "tests/tc47.ber", Error: "eoc child not allowed with definite length"},
 	{File: "tests/tc48.ber", Error: "", IndefiniteEncoding: true}, // Error: "Using of more than 7 "unused bits" in BIT STRING with constrictive encoding form"
 	{File: "tests/tc49.ber", Error: ""},
-	{File: "tests/tc50.ber", Error: is64bit("length cannot be less than -1", "long-form length overflow")},
+	{File: "tests/tc50.ber", Error: "long-form length overflow"},
 	{File: "tests/tc51.ber", Error: is64bit(fmt.Sprintf("length 206966894640 greater than maximum %v", MaxPacketLengthBytes), "long-form length overflow")},
 }
 


### PR DESCRIPTION
This PR fixes a length of 2⁶⁴-1 wrapping to -1, which made the parser treat a definite-form packet as indefinite. Lengths are now read as unsigned and rejected if negative.